### PR TITLE
Normalize mode labels in validation

### DIFF
--- a/validate_simulation_data.m
+++ b/validate_simulation_data.m
@@ -12,40 +12,50 @@ for i = 1:numel(simData)
 end
 
 % --- Verify that every location/filter/mode has both tight and leaky entries ---
-locations = unique({simData.location});
-filters   = unique({simData.filterType});
-modes     = unique({simData.mode});
+locationsAll    = string({simData.location});
+leakagesAll     = string({simData.leakage});
+filterTypesAll  = string({simData.filterType});
+rawModesAll     = string({simData.mode});
+
+normalizedModes = strings(size(rawModesAll));
+for i = 1:numel(simData)
+    normalizedModes(i) = normalize_mode(filterTypesAll(i), rawModesAll(i));
+end
+
+locations = unique(locationsAll);
+filters   = unique(filterTypesAll);
+modes     = unique(normalizedModes);
 
 for l = 1:numel(locations)
-    loc = locations{l};
+    loc = locations(l);
     % Baseline must exist for tight and leaky homes
-    for leak = {"tight","leaky"}
-        mask = strcmp({simData.location}, loc) & strcmp({simData.leakage}, leak{1}) & ...
-               strcmp({simData.filterType}, 'baseline');
+    for leak = ["tight","leaky"]
+        mask = (locationsAll == loc) & (leakagesAll == leak) & ...
+               (filterTypesAll == "baseline");
         if ~any(mask)
-            error('Missing baseline simulation for %s / %s', loc, leak{1});
+            error('Missing baseline simulation for %s / %s', char(loc), char(leak));
         end
     end
 end
 
 % Exclude baseline when checking filters
-filters = setdiff(filters, {'baseline'});
-modes = setdiff(modes, {'baseline'});
+filters = setdiff(filters, "baseline");
+modes = setdiff(modes, "baseline");
 
 for l = 1:numel(locations)
-    loc = locations{l};
+    loc = locations(l);
     for f = 1:numel(filters)
-        filt = filters{f};
+        filt = filters(f);
         for m = 1:numel(modes)
-            mode = modes{m};
-            for leak = {"tight","leaky"}
-                mask = strcmp({simData.location}, loc) & ...
-                       strcmp({simData.leakage}, leak{1}) & ...
-                       strcmp({simData.filterType}, filt) & ...
-                       strcmp({simData.mode}, mode);
+            mode = modes(m);
+            for leak = ["tight","leaky"]
+                mask = (locationsAll == loc) & ...
+                       (leakagesAll == leak) & ...
+                       (filterTypesAll == filt) & ...
+                       (normalizedModes == mode);
                 if ~any(mask)
                     error('Missing simulation for %s filter (%s) in %s / %s', ...
-                        filt, mode, loc, leak{1});
+                        char(filt), char(mode), char(loc), char(leak));
                 end
             end
         end
@@ -53,4 +63,44 @@ for l = 1:numel(locations)
 end
 
 fprintf('✓ Simulation data validated (completeness enforced)\n');
+end
+
+function modeKey = normalize_mode(filterType, rawMode)
+%NORMALIZE_MODE  Map raw filename-derived mode labels to canonical tokens.
+
+filterType = string(filterType);
+rawMode    = string(rawMode);
+
+if filterType == "baseline"
+    modeKey = "baseline";
+    return;
+end
+
+if ismissing(rawMode) || strlength(rawMode) == 0
+    modeKey = "";
+    return;
+end
+
+parts = split(rawMode, "_");
+parts(parts == "") = [];
+partsLower = lower(parts);
+
+modeKey = "";
+for k = 1:numel(partsLower)
+    token = partsLower(k);
+    if token == "active"
+        modeKey = "active";
+        return;
+    elseif token == "always_on" || token == "alwayson"
+        modeKey = "always_on";
+        return;
+    elseif token == "always" && k < numel(partsLower) && partsLower(k+1) == "on"
+        modeKey = "always_on";
+        return;
+    end
+end
+
+if modeKey == "" && ~isempty(parts)
+    modeKey = lower(parts(1));
+end
 end


### PR DESCRIPTION
## Summary
- normalize simulation mode labels by removing UUID/run suffixes and mapping to canonical `active`/`always_on` tokens during validation
- switch validation logic to operate on string arrays so baseline and filter completeness checks respect the new filename scheme

## Testing
- not run (MATLAB environment unavailable)


------
https://chatgpt.com/codex/tasks/task_e_68c98d32bc6c8327960ba1aaadcbb980