### PR TITLE
Fix filter replacement interval concatenation

### DIFF
--- a/preprocess_structure_data.m
+++ b/preprocess_structure_data.m
@@ -100,7 +100,10 @@ resetIdx = find(diff(series) > 0);
 if isempty(resetIdx)
     hours = NaN;
 else
-    intervals = diff([0 resetIdx numel(series)]);
+    % Ensure indices are treated as a single column vector before taking
+    % differences so concatenation does not fail for column-oriented input
+    intervalBoundaries = [0; resetIdx(:); numel(series)];
+    intervals = diff(intervalBoundaries);
     hours = mean(intervals);
 end
 end


### PR DESCRIPTION
## Summary
- ensure filter replacement interval computation handles column-oriented filter life series
- prevent horizontal concatenation dimension mismatch by normalizing index vector shape

## Testing
- not run (MATLAB/Octave not available in container)

------
https://chatgpt.com/codex/tasks/task_e_68c99b67e7f08327a7e90fa73850af08