### PR TITLE
Enhance figure exports for fullscreen high-resolution output

### DIFF
--- a/create_hidden_figure.m
+++ b/create_hidden_figure.m
@@ -1,4 +1,5 @@
 function fig = create_hidden_figure()
 fig = figure('Visible','off');
+set_figure_fullscreen(fig);
 tiledlayout(1,1);
 end

--- a/plot_airflow_penalty.m
+++ b/plot_airflow_penalty.m
@@ -16,7 +16,8 @@ modes = unique(tradeoffTable.mode);
 locations = unique(tradeoffTable.location);
 
 % Create figure with multiple panels
-fig = figure('Position', [100 100 1400 900], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 %% Panel 1: Main comparison by filter and mode
 subplot(2, 3, [1 2]);

--- a/plot_aqi_stacked_bars.m
+++ b/plot_aqi_stacked_bars.m
@@ -30,7 +30,8 @@ configs = unique(healthExposureTable(:,["location","filterType"]),"rows");
 scenarios = ["baseline","active","always_on"];
 
 % Create figure with proper sizing for publication quality
-hFig = figure('Visible','off', 'Position',[0 0 1400 900]);
+hFig = figure('Visible','off');
+set_figure_fullscreen(hFig);
 tiledlayout('flow','TileSpacing','compact','Padding','compact');
 
 % AQI category colors (EPA standard) - ensure colorblind accessibility
@@ -209,7 +210,7 @@ sgtitle('Indoor AQI Exposure: Mean Values with Building Envelope Uncertainty', .
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Save with high resolution
-print(hFig, fullfile(figuresDir, 'aqi_exposure_with_bounds.png'), '-dpng', '-r300');
+save_figure(hFig, figuresDir, 'aqi_exposure_with_bounds.png');
 close(hFig);
 
 end

--- a/plot_aqi_time_avoided.m
+++ b/plot_aqi_time_avoided.m
@@ -23,7 +23,8 @@ aqiNames = ["Good","Moderate","Unhealthy for Sensitive Groups", ...
 configs = unique(avoidedTable(:,["location","filterType"]),"rows");
 scenarios = ["baseline","active","always_on"];
 
-hFig = figure('Visible','off','Position',[0 0 1400 900]);
+hFig = figure('Visible','off');
+set_figure_fullscreen(hFig);
 tiledlayout('flow','TileSpacing','compact','Padding','compact');
 
 aqiColors = [
@@ -116,6 +117,6 @@ end
 sgtitle('Avoided AQI Exposure Time Relative to Outdoors', ...
     'FontSize',14,'FontWeight','bold');
 
-print(hFig, fullfile(figuresDir,'aqi_time_avoided.png'), '-dpng','-r300');
+save_figure(hFig, figuresDir, 'aqi_time_avoided.png');
 close(hFig);
 end

--- a/plot_comprehensive_bounds.m
+++ b/plot_comprehensive_bounds.m
@@ -8,7 +8,8 @@ if isempty(costTable)
     return;
 end
 
-figure('Position',[100 100 1200 800],'Visible','off');
+fig = figure('Visible','off');
+set_figure_fullscreen(fig);
 layout = tiledlayout(2,2,'TileSpacing','compact','Padding','compact');
 
 % Unique configurations (without leakage dimension)
@@ -93,6 +94,6 @@ box on; grid on;
 
 sgtitle('Comprehensive Scenario Bounds Analysis','FontSize',14,'FontWeight','bold');
 
-save_figure(gcf, figuresDir, 'comprehensive_bounds_analysis.png');
-close(gcf);
+save_figure(fig, figuresDir, 'comprehensive_bounds_analysis.png');
+close(fig);
 end

--- a/plot_configuration_overlap.m
+++ b/plot_configuration_overlap.m
@@ -7,7 +7,8 @@ if isempty(costTable)
     return;
 end
 
-figure('Position', [100 100 1200 800], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 % Get configurations
 configs = unique(costTable(:, {'location', 'filterType', 'mode'}));
@@ -256,7 +257,7 @@ sgtitle('Configuration Performance Overlap Analysis', ...
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Save
-save_figure(gcf, figuresDir, 'configuration_overlap_analysis.png');
-close(gcf);
+save_figure(fig, figuresDir, 'configuration_overlap_analysis.png');
+close(fig);
 
 end

--- a/plot_correlation_analysis.m
+++ b/plot_correlation_analysis.m
@@ -8,7 +8,8 @@ if isempty(fieldnames(correlationAnalysis))
     return;
 end
 
-figure('Position', [100 100 1600 900], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(correlationAnalysis);
 
@@ -56,6 +57,6 @@ for i = 1:nConfigs
 end
 
 sgtitle('Cross-Correlation Analysis: Indoor vs Outdoor', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'correlation_analysis.png');
-close(gcf);
+save_figure(fig, saveDir, 'correlation_analysis.png');
+close(fig);
 end

--- a/plot_cost_per_aqi_hour.m
+++ b/plot_cost_per_aqi_hour.m
@@ -73,7 +73,8 @@ for m = 1:nModes
 end
 
 % Create figure
-fig = figure('Position', [100 100 800 600], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 % Plot grouped bars with error bars
 x = 1:nModes;

--- a/plot_cumulative_exposure.m
+++ b/plot_cumulative_exposure.m
@@ -22,7 +22,8 @@ if isempty(summaryTable)
     return;
 end
 
-figure('Visible','off');
+fig = figure('Visible','off');
+set_figure_fullscreen(fig);
 tiledlayout('flow');
 
 uniqueConfigs = unique(summaryTable(:, {'location', 'filterType'}));
@@ -81,6 +82,6 @@ else
     sgTxt = sprintf('Cumulative %s %s Exposure Over Time', envLabel, pmLabel);
 end
 sgtitle(sgTxt);
-save_figure(gcf, figuresDir, fileName);
-close(gcf);
+save_figure(fig, figuresDir, fileName);
+close(fig);
 end

--- a/plot_deterministic_bounds.m
+++ b/plot_deterministic_bounds.m
@@ -11,7 +11,8 @@ if isempty(summaryTable) || isempty(costTable)
     warning('plot_deterministic_bounds: no data provided, skipping plot.');
     return;
 end
-figure('Position',[100 100 1400 900],'Visible','off');
+fig = figure('Visible','off');
+set_figure_fullscreen(fig);
 t = tiledlayout(2,3,'TileSpacing','compact','Padding','compact');
 
 % Get unique scenarios
@@ -236,6 +237,6 @@ sgtitle('Deterministic Physical Bounds Analysis: Building Envelope Performance',
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Save
-save_figure(gcf, figuresDir, 'deterministic_bounds_analysis.png');
-close(gcf);
+save_figure(fig, figuresDir, 'deterministic_bounds_analysis.png');
+close(fig);
 end

--- a/plot_dynamic_filter_comparison.m
+++ b/plot_dynamic_filter_comparison.m
@@ -8,7 +8,8 @@ if isempty(fieldnames(filterComparison))
     return;
 end
 
-figure('Position', [100 100 1600 1000], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 locations = fieldnames(filterComparison);
 
@@ -92,8 +93,8 @@ subplot(2, 2, [3 4]);
 plot_filter_radar_comparison(filterComparison);
 
 sgtitle('Dynamic Filter Performance Comparison - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'filter_comparison_dynamic.png');
-close(gcf);
+save_figure(fig, saveDir, 'filter_comparison_dynamic.png');
+close(fig);
 end
 
 function plot_filter_radar_comparison(filterComparison)

--- a/plot_efficacy_scores.m
+++ b/plot_efficacy_scores.m
@@ -11,7 +11,8 @@ if isempty(efficacyScoreTable)
 end
 
 % Create comprehensive efficacy visualization
-figure('Position',[100 100 1400 900],'Visible','off');
+fig = figure('Visible','off');
+set_figure_fullscreen(fig);
 tiledlayout(2,3,'TileSpacing','compact','Padding','compact');
 
 % Sort by rank for consistent ordering
@@ -157,8 +158,8 @@ sgtitle('Composite Efficacy Score Analysis: Multi-Criteria Performance Evaluatio
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Save
-save_figure(gcf, figuresDir, 'efficacy_scores_comprehensive.png');
-close(gcf);
+save_figure(fig, figuresDir, 'efficacy_scores_comprehensive.png');
+close(fig);
 
 %% Create summary ranking table visualization
 create_efficacy_ranking_table(efficacyScoreTable, figuresDir);
@@ -168,7 +169,8 @@ end
 function create_efficacy_ranking_table(efficacyScoreTable, figuresDir)
 % Create a clean table visualization of the ranking without UI components
 
-fig = figure('Position',[100 100 1000 600],'Visible','off');
+fig = figure('Visible','off');
+set_figure_fullscreen(fig);
 ax = axes('Parent', fig, 'Position',[0.05 0.18 0.9 0.74]);
 axis(ax, 'off');
 

--- a/plot_envelope_sensitivity.m
+++ b/plot_envelope_sensitivity.m
@@ -5,7 +5,8 @@ if isempty(summaryTable) || isempty(costTable)
     warning('plot_envelope_sensitivity: no data provided, skipping plot.');
     return;
 end
-figure('Position',[100 100 1200 800],'Visible','off');
+fig = figure('Visible','off');
+set_figure_fullscreen(fig);
 
 %% Calculate sensitivity indices with enhanced zero handling
 scenarios = unique(summaryTable(~strcmp(summaryTable.mode,'baseline'), ...
@@ -303,6 +304,6 @@ sgtitle('Building Envelope Sensitivity Analysis: Impact of Leakage on System Per
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Save
-save_figure(gcf, figuresDir, 'envelope_sensitivity_analysis.png');
-close(gcf);
+save_figure(fig, figuresDir, 'envelope_sensitivity_analysis.png');
+close(fig);
 end

--- a/plot_event_metric_distributions.m
+++ b/plot_event_metric_distributions.m
@@ -29,6 +29,7 @@ grpLabels = strcat(strrep(groups(:,1),'_',' '), " (", groups(:,2), ")");
 for m = 1:numel(metrics)
     metric = metrics{m};
     fig = figure('Visible','off');
+    set_figure_fullscreen(fig);
     tiledlayout(1,2);
     % Boxplot
     nexttile;

--- a/plot_event_response_analysis.m
+++ b/plot_event_response_analysis.m
@@ -8,7 +8,8 @@ if isempty(fieldnames(eventAnalysis))
     return;
 end
 
-figure('Position', [100 100 1600 1000], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(eventAnalysis);
 colors = get_color_palette(length(configs));
@@ -153,8 +154,8 @@ subplot(2, 3, [4 6]);
 plot_example_event_responses(eventAnalysis);
 
 sgtitle('Pollution Event Response Analysis - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'event_response_analysis.png');
-close(gcf);
+save_figure(fig, saveDir, 'event_response_analysis.png');
+close(fig);
 end
 
 function plot_example_event_responses(eventAnalysis)

--- a/plot_executive_summary.m
+++ b/plot_executive_summary.m
@@ -17,7 +17,8 @@ hasBounds = ismember('percent_PM25_reduction_lower', costTable.Properties.Variab
 configs = unique(costTable(:, {'location', 'filterType', 'mode'}));
 colors = lines(height(configs));
 
-fig = figure('Position', [100 100 1400 900], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 %% Panel 1: Active metrics for Bakersfield
 subplot(2, 3, 1);

--- a/plot_filter_life_envelope.m
+++ b/plot_filter_life_envelope.m
@@ -35,7 +35,8 @@ nConfigs = height(configs);
 nCols = min(3, nConfigs);
 nRows = ceil(nConfigs / nCols);
 
-fig = figure('Position', [50 50 1400 900], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 tiledlayout(nRows, nCols, 'TileSpacing', 'compact', 'Padding', 'compact');
 
 % Process each configuration

--- a/plot_filter_replacement.m
+++ b/plot_filter_replacement.m
@@ -54,7 +54,8 @@ for m = 1:nModes
 end
 
 % Create figure
-fig = figure('Position', [100 100 900 600], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 % Main plot - grouped bars with error bars
 subplot(1, 2, 1);

--- a/plot_intervention_efficacy_dashboard.m
+++ b/plot_intervention_efficacy_dashboard.m
@@ -14,7 +14,8 @@ if isempty(summaryTable) || isempty(costTable) || isempty(healthExposureTable)
 end
 
 %% Setup
-figure('Position',[50 50 1800 1000],'Visible','off', 'Color','white');
+fig = figure('Visible','off', 'Color','white');
+set_figure_fullscreen(fig);
 
 % Define consistent color scheme
 colorBaseline = [0.5 0.5 0.5];
@@ -54,9 +55,9 @@ plotEfficacyScorecard(costTable, healthExposureTable);
 if ~exist(figuresDir, 'dir')
     mkdir(figuresDir);
 end
-saveas(gcf, fullfile(figuresDir, 'intervention_efficacy_dashboard.png'));
-print(gcf, fullfile(figuresDir, 'intervention_efficacy_dashboard_hires.png'), '-dpng', '-r300');
-close(gcf);
+save_figure(fig, figuresDir, 'intervention_efficacy_dashboard.png');
+save_figure(fig, figuresDir, 'intervention_efficacy_dashboard_hires.png');
+close(fig);
 
 end
 

--- a/plot_intervention_matrix.m
+++ b/plot_intervention_matrix.m
@@ -69,7 +69,8 @@ for l = 1:nLoc
 end
 
 % Create figure
-fig = figure('Position', [100 100 1000 600], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 ax1 = axes('Parent', fig);
 
 % Main heatmap

--- a/plot_io_ratio_dynamics.m
+++ b/plot_io_ratio_dynamics.m
@@ -1,5 +1,6 @@
 function plot_io_ratio_dynamics(ioAnalysis, saveDir)
-figure('Position', [100 100 1400 900], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 configs = fieldnames(ioAnalysis);
 nConfigs = numel(configs);
 
@@ -44,6 +45,6 @@ for i = 1:nConfigs
 end
 
 sgtitle('Indoor/Outdoor Ratio Dynamics - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'io_ratio_dynamics.png');
-close(gcf);
+save_figure(fig, saveDir, 'io_ratio_dynamics.png');
+close(fig);
 end

--- a/plot_penetration_analysis.m
+++ b/plot_penetration_analysis.m
@@ -9,7 +9,8 @@ if isempty(fieldnames(penetrationAnalysis))
     return;
 end
 
-figure('Position', [100 100 1400 900], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(penetrationAnalysis);
 nConfigs = length(configs);
@@ -124,6 +125,6 @@ if isfield(data, 'hourly_penetration_pm25')
 end
 
 sgtitle('Particle Penetration Analysis - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'penetration_analysis.png');
-close(gcf);
+save_figure(fig, saveDir, 'penetration_analysis.png');
+close(fig);
 end

--- a/plot_pm_envelope.m
+++ b/plot_pm_envelope.m
@@ -51,7 +51,8 @@ for i = 1:height(configs)
     if isempty(rows), continue; end
 
     % Create sophisticated multi-panel figure
-    figure('Position',[100 100 1400 900],'Visible','off');
+    fig = figure('Visible','off');
+    set_figure_fullscreen(fig);
     tiledlayout(2,2,'TileSpacing','compact','Padding','compact');
 
     modes = unique(rows.mode);
@@ -245,7 +246,7 @@ for i = 1:height(configs)
     filtStr = matlab.lang.makeValidName(filtStr);
 
     fname = sprintf('%s_%s_%s_enhanced.png', prefix, locStr, filtStr);
-    save_figure(gcf, figuresDir, fullfile(locStr, filtStr), fname);
-    close(gcf);
+    save_figure(fig, figuresDir, fullfile(locStr, filtStr), fname);
+    close(fig);
 end
 end

--- a/plot_scalar_ranges.m
+++ b/plot_scalar_ranges.m
@@ -45,7 +45,9 @@ if ~exist(figuresDir, 'dir')
     mkdir(figuresDir);
 end
 
-figure('Visible','off'); hold on;
+fig = figure('Visible','off');
+set_figure_fullscreen(fig);
+hold on;
 
 % Plot bars representing mean values
 b = bar(1:height(rows), rows.mean, 'FaceColor','flat');
@@ -63,6 +65,6 @@ title(sprintf('Range: %s (tight vs. leaky)', metricName), 'Interpreter','none');
 grid on;
 
 fname = sprintf('%s_range.png', metricName);
-save_figure(gcf, figuresDir, fname);
-close(gcf);
+save_figure(fig, figuresDir, fname);
+close(fig);
 end

--- a/plot_statistical_summary.m
+++ b/plot_statistical_summary.m
@@ -4,7 +4,8 @@ if isempty(summaryTable) || isempty(rangeTable)
     warning('plot_statistical_summary: no data provided, skipping plot.');
     return;
 end
-figure('Position',[50 50 1600 900],'Visible','off');
+fig = figure('Visible','off');
+set_figure_fullscreen(fig);
 
 %% Calculate summary statistics
 configs = unique(summaryTable(:,{'location','filterType','mode'}));
@@ -147,6 +148,6 @@ sgtitle('Statistical Summary: Building Envelope Range Analysis', ...
     'FontSize', 16, 'FontWeight', 'bold');
 
 % Save
-save_figure(gcf, figuresDir, 'statistical_summary_bounds.png');
-close(gcf);
+save_figure(fig, figuresDir, 'statistical_summary_bounds.png');
+close(fig);
 end

--- a/plot_temporal_patterns.m
+++ b/plot_temporal_patterns.m
@@ -8,7 +8,8 @@ if isempty(fieldnames(temporalAnalysis))
     return;
 end
 
-figure('Position', [100 100 1400 1000], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(temporalAnalysis);
 
@@ -122,6 +123,6 @@ end
 grid on;
 
 sgtitle('Temporal Patterns in Active Mode Performance', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'temporal_patterns.png');
-close(gcf);
+save_figure(fig, saveDir, 'temporal_patterns.png');
+close(fig);
 end

--- a/plot_trigger_response_analysis.m
+++ b/plot_trigger_response_analysis.m
@@ -15,7 +15,8 @@ if isempty(fieldnames(triggerAnalysis))
     return;
 end
 
-figure('Position', [100 100 1600 1000], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(triggerAnalysis);
 nConfigs = length(configs);
@@ -146,13 +147,14 @@ else
 end
 
 sgtitle('Trigger Response Analysis - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'trigger_response_analysis.png');
-close(gcf);
+save_figure(fig, saveDir, 'trigger_response_analysis.png');
+close(fig);
 end
 
 %% Visualization Function 3: Penetration Analysis
 function plot_penetration_analysis(penetrationAnalysis, saveDir)
-figure('Position', [100 100 1400 900], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(penetrationAnalysis);
 nConfigs = length(configs);
@@ -263,13 +265,14 @@ if isfield(data, 'hourly_penetration_pm25')
 end
 
 sgtitle('Particle Penetration Analysis - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'penetration_analysis.png');
-close(gcf);
+save_figure(fig, saveDir, 'penetration_analysis.png');
+close(fig);
 end
 
 %% Visualization Function 4: Event Response Analysis
 function plot_event_response_analysis(eventAnalysis, saveDir)
-figure('Position', [100 100 1600 1000], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(eventAnalysis);
 colors = get_color_palette(length(configs));
@@ -388,13 +391,14 @@ subplot(2, 3, [4 6]);
 plot_example_event_responses(eventAnalysis);
 
 sgtitle('Pollution Event Response Analysis - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'event_response_analysis.png');
-close(gcf);
+save_figure(fig, saveDir, 'event_response_analysis.png');
+close(fig);
 end
 
 %% Visualization Function 5: Temporal Patterns
 function plot_temporal_patterns(temporalAnalysis, saveDir)
-figure('Position', [100 100 1400 1000], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(temporalAnalysis);
 
@@ -463,13 +467,14 @@ legend(strrep(configs, '_', ' '), 'Location', 'best');
 grid on;
 
 sgtitle('Temporal Patterns in Active Mode Performance', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'temporal_patterns.png');
-close(gcf);
+save_figure(fig, saveDir, 'temporal_patterns.png');
+close(fig);
 end
 
 %% Visualization Function 6: Cross-Correlation Analysis
 function plot_correlation_analysis(correlationAnalysis, saveDir)
-figure('Position', [100 100 1600 900], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(correlationAnalysis);
 
@@ -508,13 +513,14 @@ for i = 1:nConfigs
 end
 
 sgtitle('Cross-Correlation Analysis: Indoor vs Outdoor', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'correlation_analysis.png');
-close(gcf);
+save_figure(fig, saveDir, 'correlation_analysis.png');
+close(fig);
 end
 
 %% Visualization Function 7: Dynamic Filter Comparison
 function plot_dynamic_filter_comparison(filterComparison, saveDir)
-figure('Position', [100 100 1600 1000], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 locations = fieldnames(filterComparison);
 
@@ -568,13 +574,14 @@ subplot(2, 2, [3 4]);
 plot_filter_radar_comparison(filterComparison);
 
 sgtitle('Dynamic Filter Performance Comparison - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'filter_comparison_dynamic.png');
-close(gcf);
+save_figure(fig, saveDir, 'filter_comparison_dynamic.png');
+close(fig);
 end
 
 %% Visualization Function 8: Uncertainty Analysis
 function plot_uncertainty_analysis(uncertaintyAnalysis, saveDir)
-figure('Position', [100 100 1400 900], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(uncertaintyAnalysis);
 
@@ -655,8 +662,8 @@ subplot(2, 2, 4);
 plot_sensitivity_tornado(uncertaintyAnalysis);
 
 sgtitle('Uncertainty Quantification - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'uncertainty_analysis.png');
-close(gcf);
+save_figure(fig, saveDir, 'uncertainty_analysis.png');
+close(fig);
 end
 
 %% Helper visualization functions

--- a/plot_uncertainty_analysis.m
+++ b/plot_uncertainty_analysis.m
@@ -8,7 +8,8 @@ if isempty(fieldnames(uncertaintyAnalysis))
     return;
 end
 
-figure('Position', [100 100 1400 900], 'Visible', 'off');
+fig = figure('Visible', 'off');
+set_figure_fullscreen(fig);
 
 configs = fieldnames(uncertaintyAnalysis);
 
@@ -102,8 +103,8 @@ subplot(2, 2, 4);
 plot_sensitivity_tornado(uncertaintyAnalysis);
 
 sgtitle('Scenario Bounds Quantification - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
-save_figure(gcf, saveDir, 'uncertainty_analysis.png');
-close(gcf);
+save_figure(fig, saveDir, 'uncertainty_analysis.png');
+close(fig);
 end
 
 function plot_sensitivity_tornado(uncertaintyAnalysis)

--- a/save_figure.m
+++ b/save_figure.m
@@ -26,15 +26,31 @@ end
 
 outFile = fullfile(outDir, fileName);
 
+% Maximize the figure so on-screen windows and exports fill the screen
+set_figure_fullscreen(fig);
+
+% Choose a higher resolution automatically for files tagged as "hires"
+resolution = 300;
+lowerName = lower(fileName);
+if contains(lowerName, 'hires') || contains(lowerName, 'highres') || ...
+        contains(lowerName, 'hi_res') || contains(lowerName, 'high_res')
+    resolution = 450;
+end
+
+% Make sure all graphics updates are applied before exporting
+drawnow;
+
 % Detect UI components like uitable/uicontrol that require exportapp
 uiComponents = findall(fig, 'Type', 'uitable', '-or', 'Type', 'uicontrol');
 if ~isempty(uiComponents)
     try
-        exportapp(fig, outFile);
+        exportapp(fig, outFile, 'Resolution', resolution);
     catch
-        exportgraphics(fig, outFile);
+        exportgraphics(fig, outFile, 'ContentType', 'image', ...
+            'BackgroundColor', 'white', 'Resolution', resolution);
     end
 else
-    exportgraphics(fig, outFile);
+    exportgraphics(fig, outFile, 'ContentType', 'image', ...
+        'BackgroundColor', 'white', 'Resolution', resolution);
 end
 end

--- a/set_figure_fullscreen.m
+++ b/set_figure_fullscreen.m
@@ -1,0 +1,45 @@
+function set_figure_fullscreen(fig)
+%SET_FIGURE_FULLSCREEN Expand a figure window to fill the available screen.
+%   SET_FIGURE_FULLSCREEN(FIG) resizes FIG so it occupies the full screen
+%   and configures it for high-resolution export. If FIG is omitted, the
+%   current figure (GCF) is used.
+
+if nargin < 1 || isempty(fig)
+    fig = gcf;
+end
+
+if ~isa(fig, 'matlab.ui.Figure')
+    error('set_figure_fullscreen expects a figure handle.');
+end
+
+% Ensure the figure has a white background for export consistency
+fig.Color = 'white';
+
+% Try to set the figure to fill the available screen real estate. The
+% normalized approach works across different monitor sizes and DPI
+% settings, while the pixel fallback covers headless or unusual setups.
+try
+    fig.Units = 'normalized';
+    fig.OuterPosition = [0 0 1 1];
+catch
+    try
+        fig.Units = 'pixels';
+        screenSize = get(0, 'ScreenSize');
+        fig.Position = [screenSize(1:2), screenSize(3), screenSize(4)];
+    catch
+        % If neither approach works we silently fall back to the existing
+        % figure size.
+    end
+end
+
+% Match on-screen and export sizing
+try
+    fig.PaperPositionMode = 'auto';
+catch
+    % Some figure types do not expose PaperPositionMode; ignore gracefully.
+end
+
+% Apply the resize immediately so subsequent layout commands see the new
+% geometry.
+drawnow limitrate nocallbacks;
+end


### PR DESCRIPTION
## Summary
- add a `set_figure_fullscreen` helper and update `save_figure` to maximize figures and export higher-resolution PNGs automatically
- update plotting routines to create fullscreen windows before rendering and rely on `save_figure` for consistent saving
- replace direct print/save calls with the enhanced helper so generated dashboards and analyses share the new export behavior

## Testing
- not run (Matlab environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9abd8d0a88327ab9959674c412e60