### PR TITLE
Fix efficacy ranking table export visibility

### DIFF
--- a/plot_efficacy_scores.m
+++ b/plot_efficacy_scores.m
@@ -172,7 +172,14 @@ function create_efficacy_ranking_table(efficacyScoreTable, figuresDir)
 
 fig = figure('Position',[100 100 1000 600],'Visible','off');
 ax = axes('Parent', fig, 'Position',[0.05 0.18 0.9 0.74]);
-axis(ax, 'off');
+
+% Hide axis visuals without disabling visibility (exportgraphics ignores
+% children of invisible axes when saving figures)
+set(ax, 'XTick', [], 'YTick', [], 'Box', 'off', 'Color', 'none');
+if isprop(ax, 'XAxis') % Guard for Octave compatibility
+    ax.XAxis.Visible = 'off';
+    ax.YAxis.Visible = 'off';
+end
 
 % Prepare table data
 nRows = min(10, height(efficacyScoreTable)); % Show top 10


### PR DESCRIPTION
## Summary
- update the efficacy ranking table axes styling so the rectangles and text remain visible to exportgraphics
- keep tick marks hidden while ensuring compatibility with MATLAB/Octave environments

## Testing
- not run (MATLAB environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9ad9fb6108327bd76d025f3afdf6b