### PR TITLE
Clarify filter replacement range plot

### DIFF
--- a/build_range_table.m
+++ b/build_range_table.m
@@ -64,23 +64,33 @@ for i = 1:rows
         leaky_val(idx) = valL;
 
         % Compute bounds (min/max regardless of which is tight/leaky)
-        lower_bound(idx) = min(valT, valL);
-        upper_bound(idx) = max(valT, valL);
-        mean_val(idx) = (valT + valL) / 2;
-
-        % Range metrics
-        range_width(idx) = upper_bound(idx) - lower_bound(idx);
-        if mean_val(idx) ~= 0
-            range_percent(idx) = 100 * range_width(idx) / abs(mean_val(idx));
+        vals = [valT, valL];
+        validMask = ~isnan(vals);
+        if any(validMask)
+            validVals = vals(validMask);
+            lower_bound(idx) = min(validVals);
+            upper_bound(idx) = max(validVals);
+            mean_val(idx) = mean(validVals);
         else
-            range_percent(idx) = 0;
+            lower_bound(idx) = NaN;
+            upper_bound(idx) = NaN;
+            mean_val(idx) = NaN;
         end
 
-        % Range factor (deterministic envelope spread relative to mean)
-        if mean_val(idx) ~= 0
-            range_factor(idx) = upper_bound(idx) / mean_val(idx);
+        % Range metrics
+        if any(validMask)
+            range_width(idx) = upper_bound(idx) - lower_bound(idx);
+            if mean_val(idx) ~= 0 && isfinite(mean_val(idx))
+                range_percent(idx) = 100 * range_width(idx) / abs(mean_val(idx));
+                range_factor(idx) = upper_bound(idx) / mean_val(idx);
+            else
+                range_percent(idx) = 0;
+                range_factor(idx) = 1;
+            end
         else
-            range_factor(idx) = 1;
+            range_width(idx) = NaN;
+            range_percent(idx) = NaN;
+            range_factor(idx) = NaN;
         end
     end
 end

--- a/generate_all_plots.m
+++ b/generate_all_plots.m
@@ -54,7 +54,7 @@ allCats = strcat(strrep(rangeTable.location,'_','-'), "-", ...
 uniqueCats = unique(allCats, 'stable');
 rangeColors = get_color_palette(numel(uniqueCats));
 for i = 1:numel(rangeMetrics)
-    plot_scalar_ranges(rangeTable, rangeMetrics{i}, cats.ranges, uniqueCats, rangeColors);
+    plot_scalar_ranges(rangeTable, rangeMetrics{i}, cats.ranges, uniqueCats, rangeColors, summaryTable);
 end
 
 % --- Summary visualizations ---

--- a/plot_scalar_ranges.m
+++ b/plot_scalar_ranges.m
@@ -1,10 +1,15 @@
-function plot_scalar_ranges(rangeTable, metricName, figuresDir, categories, colorMap)
+function plot_scalar_ranges(rangeTable, metricName, figuresDir, categories, colorMap, summaryTable)
 % PLOT_SCALAR_RANGES  Plot mean values with tight/leaky ranges as error bars.
-%   rangeTable : table produced by build_range_table
-%   metricName : name of metric to visualize
-%   figuresDir : folder to save output PNG
-%   categories : (optional) cell array specifying global category order
-%   colorMap   : (optional) Nx3 array of RGB colors matching categories
+%   rangeTable   : table produced by build_range_table
+%   metricName   : name of metric to visualize
+%   figuresDir   : folder to save output PNG
+%   categories   : (optional) cell array specifying global category order
+%   colorMap     : (optional) Nx3 array of RGB colors matching categories
+%   summaryTable : (optional) table with raw scenario data for derived metrics
+
+if nargin < 6
+    summaryTable = [];
+end
 
 rows = rangeTable(strcmp(rangeTable.metric, metricName), :);
 if isempty(rows)
@@ -49,22 +54,153 @@ fig = figure('Visible','off');
 set_figure_fullscreen(fig);
 hold on;
 
-% Plot bars representing mean values
-b = bar(1:height(rows), rows.mean, 'FaceColor','flat');
+% Determine default plotting values
+values = rows.mean;
+lowerBounds = rows.lower_bound;
+upperBounds = rows.upper_bound;
+yLabelText = metricName;
+titleText = sprintf('Range: %s (tight vs. leaky)', metricName);
+noteText = '';
+
+if strcmp(metricName, 'filter_replaced')
+    hoursPerYear = 8760; % Consistent assumption used throughout reports
+    hasEventData = ~isempty(summaryTable) && ...
+        all(ismember({'filter_replacement_events','filter_runtime_hours','leakage'}, ...
+        summaryTable.Properties.VariableNames));
+
+    tightRates = nan(height(rows),1);
+    leakyRates = nan(height(rows),1);
+
+    for i = 1:height(rows)
+        loc = rows.location{i};
+        filt = rows.filterType{i};
+        mode = rows.mode{i};
+
+        if hasEventData
+            tightRow = summaryTable(strcmp(summaryTable.location, loc) & ...
+                strcmp(summaryTable.filterType, filt) & ...
+                strcmp(summaryTable.mode, mode) & ...
+                strcmp(summaryTable.leakage, 'tight'), :);
+            leakyRow = summaryTable(strcmp(summaryTable.location, loc) & ...
+                strcmp(summaryTable.filterType, filt) & ...
+                strcmp(summaryTable.mode, mode) & ...
+                strcmp(summaryTable.leakage, 'leaky'), :);
+        else
+            tightRow = table();
+            leakyRow = table();
+        end
+
+        tightRates(i) = compute_replacement_rate_from_row(tightRow, ...
+            rows.tight_value(i), hoursPerYear);
+        leakyRates(i) = compute_replacement_rate_from_row(leakyRow, ...
+            rows.leaky_value(i), hoursPerYear);
+    end
+
+    rateMatrix = [tightRates, leakyRates];
+    values = mean(rateMatrix, 2, 'omitnan');
+    lowerBounds = min(rateMatrix, [], 2, 'omitnan');
+    upperBounds = max(rateMatrix, [], 2, 'omitnan');
+
+    % Replace remaining NaNs with zeros so every scenario appears in the chart
+    missingMask = isnan(values) | isnan(lowerBounds) | isnan(upperBounds);
+    values(missingMask) = 0;
+    lowerBounds(missingMask) = 0;
+    upperBounds(missingMask) = 0;
+
+    yLabelText = 'Filter Replacements per Year';
+    titleText = 'Range: Filter Replacement Frequency (tight vs. leaky)';
+    noteText = 'Derived from simulated replacement events; 0 indicates no replacements observed.';
+end
+
+% Plot bars representing the derived values
+b = bar(1:height(rows), values, 'FaceColor','flat');
 b.CData = colors;
 
 % Overlay error bars showing tight/leaky range
-errorbar(1:height(rows), rows.mean, ...
-    rows.mean - rows.lower_bound, rows.upper_bound - rows.mean, ...
+errorbar(1:height(rows), values, ...
+    values - lowerBounds, upperBounds - values, ...
     'k', 'LineStyle','none', 'LineWidth',1.5, 'CapSize',8);
 xticks(1:height(rows));
 xticklabels(cats);
 xtickangle(45);
-ylabel(metricName, 'Interpreter','none');
-title(sprintf('Range: %s (tight vs. leaky)', metricName), 'Interpreter','none');
+ylabel(yLabelText, 'Interpreter','none');
+title(titleText, 'Interpreter','none');
 grid on;
+
+if strcmp(metricName, 'filter_replaced')
+    maxUpper = max(upperBounds, [], 'omitnan');
+    if isempty(maxUpper) || isnan(maxUpper) || maxUpper <= 0
+        ylim([0 1]);
+    else
+        ylim([0 maxUpper * 1.1]);
+    end
+
+    if ~isempty(noteText)
+        annotation('textbox', [0 0 1 0.04], 'String', noteText, ...
+            'Units', 'normalized', 'HorizontalAlignment', 'center', ...
+            'VerticalAlignment', 'bottom', 'EdgeColor', 'none', ...
+            'Interpreter', 'none', 'FontAngle', 'italic');
+    end
+end
 
 fname = sprintf('%s_range.png', metricName);
 save_figure(fig, figuresDir, fname);
 close(fig);
+end
+
+function rate = compute_replacement_rate_from_row(row, fallbackHours, hoursPerYear)
+%COMPUTE_REPLACEMENT_RATE_FROM_ROW Convert raw replacement stats to per-year rate.
+
+rate = NaN;
+
+if ~isempty(row)
+    events = row.filter_replacement_events;
+    runtime = row.filter_runtime_hours;
+    if ~isempty(events)
+        events = events(1);
+    end
+    if ~isempty(runtime)
+        runtime = runtime(1);
+    end
+
+    if ~isnan(events) && ~isnan(runtime) && runtime > 0
+        yearsSimulated = runtime / hoursPerYear;
+        if yearsSimulated > 0
+            rate = events / yearsSimulated;
+        end
+    end
+
+    if isnan(rate)
+        hoursBetween = row.filter_replaced;
+        if ~isempty(hoursBetween)
+            hoursBetween = hoursBetween(1);
+        end
+        if ~isnan(hoursBetween) && hoursBetween > 0
+            rate = hoursPerYear / hoursBetween;
+        end
+    end
+end
+
+% Fall back to using the values already stored in the range table when the
+% summary table lacks the enhanced event data (e.g., legacy results).
+if isnan(rate)
+    rate = convert_hours_to_rate(fallbackHours, hoursPerYear);
+end
+
+% Ensure the rate is non-negative even if numerical noise creeps in
+if isnan(rate)
+    rate = NaN;
+elseif rate < 0
+    rate = 0;
+end
+end
+
+function rate = convert_hours_to_rate(hoursValue, hoursPerYear)
+%CONVERT_HOURS_TO_RATE Convert average hours between replacements to rate.
+
+if isnan(hoursValue) || hoursValue <= 0
+    rate = NaN;
+else
+    rate = hoursPerYear / hoursValue;
+end
 end


### PR DESCRIPTION
## Summary
- capture filter replacement event counts and runtime in preprocessing so downstream plots know when no swaps occurred
- make the range table and scalar range plot tolerant of missing/partial filter data and render replacements as annual frequencies with explanatory text
- pass the summary table into the range plotting routine so all scenarios now populate the filter replacement figure

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9b750e85c83278d9b8e84b79b28d0