### PR TITLE
Refine visualization titles

### DIFF
--- a/plot_airflow_penalty.m
+++ b/plot_airflow_penalty.m
@@ -86,7 +86,7 @@ text(0.5, 20.5, 'Noticeable Impact (20%)', 'FontSize', 9, 'Color', [0.8 0.4 0]);
 
 set(gca, 'XTick', x, 'XTickLabel', modes);
 ylabel('Airflow Reduction (%)');
-title('Airflow Penalty by Filter Type and Operating Mode');
+title('Airflow Penalty Across Filter Types and Operating Modes');
 legend(filters, 'Location', 'northwest');
 grid on;
 % Account for complex values when determining y-limits
@@ -160,7 +160,7 @@ for i = 1:length(b)
 end
 set(gca, 'XTick', 1:length(locations), 'XTickLabel', locations);
 ylabel('Mean Airflow Penalty (%)');
-title('Location-Specific Airflow Impact');
+title('Location Specific Airflow Impact');
 legend(filters, 'Location', 'best');
 grid on;
 
@@ -245,7 +245,7 @@ for i = 1:height(tradeoffTable)
 end
 xlabel('Mean Airflow Penalty (%)');
 ylabel('Uncertainty Range (% points)');
-title('Airflow Penalty vs. Uncertainty');
+title('Airflow Penalty Versus Uncertainty Range');
 grid on;
 
 h1 = plot(NaN, NaN, 'o', 'MarkerSize', 10, 'MarkerFaceColor', [0.2 0.4 0.8], 'MarkerEdgeColor', 'k');
@@ -262,7 +262,7 @@ if length(allMeans) > 5
     end
 end
 
-sgtitle('Comprehensive Airflow Penalty Analysis with Consistent Methodology', ...
+sgtitle('Comprehensive Airflow Penalty Analysis Using Consistent Methodology', ...
         'FontSize', 14, 'FontWeight', 'bold');
 
 save_figure(fig, figuresDir, 'airflow_penalty_comprehensive_improved.png');

--- a/plot_aqi_stacked_bars.m
+++ b/plot_aqi_stacked_bars.m
@@ -178,7 +178,7 @@ for i = 1:height(configs)
     ylabel('Hours', 'FontSize', 11);
     
     % Clean title formatting
-    titleStr = sprintf('%s - %s', ...
+    titleStr = sprintf('Air Quality Exposure for %s with %s Filter', ...
         strrep(loc,'_',' '), strrep(filt,'_',' '));
     title(titleStr, 'FontSize', 12);
     
@@ -206,7 +206,7 @@ for i = 1:height(configs)
 end
 
 % Overall title with clear description
-sgtitle('Indoor AQI Exposure: Mean Values with Building Envelope Uncertainty', ...
+sgtitle('Indoor Air Quality Index Exposure Mean Values with Building Envelope Uncertainty', ...
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Save with high resolution

--- a/plot_aqi_time_avoided.m
+++ b/plot_aqi_time_avoided.m
@@ -99,7 +99,8 @@ for i = 1:height(configs)
 
     set(gca,'XTick',1:numel(scenarios),'XTickLabel',cellstr(scenarios));
     ylabel('Hours Avoided');
-    title(sprintf('%s - %s',loc,filt),'Interpreter','none');
+    title(sprintf('Avoided Exposure for %s with %s Filter', ...
+        strrep(loc,'_',' '), strrep(filt,'_',' ')),'Interpreter','none');
     grid on;
     ylim([0 max(totalUpper)*1.1]);
 
@@ -114,7 +115,7 @@ for i = 1:height(configs)
     end
 end
 
-sgtitle('Avoided AQI Exposure Time Relative to Outdoors', ...
+sgtitle('Avoided Air Quality Index Exposure Time Relative to Outdoors', ...
     'FontSize',14,'FontWeight','bold');
 
 save_figure(hFig, figuresDir, 'aqi_time_avoided.png');

--- a/plot_comprehensive_bounds.m
+++ b/plot_comprehensive_bounds.m
@@ -50,7 +50,7 @@ end
 set(gca,'YTick',1:nConfigs,'YTickLabel',labels);
 ylabel('Scenario');
 xlabel('Total Cost ($)');
-title('Cost Bounds');
+title('Cost Bounds Across Scenarios');
 box on; grid on;
 
 %% Subplot 2: PM2.5 reduction bounds
@@ -62,7 +62,7 @@ end
 set(gca,'YTick',1:nConfigs,'YTickLabel',labels);
 ylabel('Scenario');
 xlabel('PM2.5 Reduction (%)');
-title('PM2.5 Reduction Bounds');
+title('Fine Particulate Matter Reduction Bounds');
 box on; grid on;
 
 %% Subplot 3: PM10 reduction bounds
@@ -74,7 +74,7 @@ end
 set(gca,'YTick',1:nConfigs,'YTickLabel',labels);
 ylabel('Scenario');
 xlabel('PM10 Reduction (%)');
-title('PM10 Reduction Bounds');
+title('Coarse Particulate Matter Reduction Bounds');
 box on; grid on;
 
 %% Subplot 4: AQI hours avoided bounds with diagnostics
@@ -89,10 +89,10 @@ end
 set(gca,'YTick',1:nConfigs,'YTickLabel',labels);
 ylabel('Scenario');
 xlabel('AQI Hours Avoided');
-title('AQI Hours Avoided Bounds');
+title('Air Quality Index Hours Avoided Bounds');
 box on; grid on;
 
-sgtitle('Comprehensive Scenario Bounds Analysis','FontSize',14,'FontWeight','bold');
+sgtitle('Comprehensive Scenario Bounds Analysis Across Metrics','FontSize',14,'FontWeight','bold');
 
 save_figure(fig, figuresDir, 'comprehensive_bounds_analysis.png');
 close(fig);

--- a/plot_configuration_overlap.m
+++ b/plot_configuration_overlap.m
@@ -74,7 +74,7 @@ end
 
 set(gca, 'YTick', y, 'YTickLabel', labels(sortIdx));
 xlabel('PM2.5 Reduction (%)');
-title('PM2.5 Reduction with Bounds');
+title('Fine Particulate Matter Reduction with Envelope Bounds');
 grid on;
 
 % Add legend for filter types without obscuring data
@@ -165,7 +165,7 @@ end
 
 set(gca, 'YTick', y, 'YTickLabel', labels(sortIdx));
 xlabel('Annual Cost ($)');
-title('Operating Cost with Bounds');
+title('Operating Cost with Envelope Bounds');
 grid on;
 
 %% Panel 3: 2D Overlap Regions
@@ -226,7 +226,7 @@ end
 
 xlabel('PM2.5 Reduction (%)');
 ylabel('Annual Cost ($)');
-title('Performance Overlap Regions');
+title('Performance Overlap Across Configurations');
 grid on;
 
 % Add diagonal lines for equal value
@@ -253,7 +253,7 @@ text(xlims(2)*0.02, ylims(2)*0.98, strjoin(legendText, '\n'), ...
     'BackgroundColor', 'w', 'EdgeColor', 'k');
 
 % Overall title
-sgtitle('Configuration Performance Overlap Analysis', ...
+sgtitle('Configuration Performance Overlap Analysis Across Envelopes', ...
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Save

--- a/plot_correlation_analysis.m
+++ b/plot_correlation_analysis.m
@@ -47,7 +47,7 @@ for i = 1:nConfigs
 
         xlabel('Lag (hours)');
         ylabel('Cross-Correlation');
-        title(sprintf('%s\nOptimal Lag: PM2.5=%dh, PM10=%dh', ...
+        title(sprintf('%s\nOptimal Lag Fine Particulate Matter 2.5 Micrometers = %dh, Coarse Particulate Matter 10 Micrometers = %dh', ...
             strrep(config, '_', ' '), ...
             data.lags(max_idx_pm25), data.lags(max_idx_pm10)));
         legend({'PM2.5 Bounds','PM10 Bounds','PM2.5','PM10'}, 'Location', 'best');
@@ -56,7 +56,7 @@ for i = 1:nConfigs
     end
 end
 
-sgtitle('Cross-Correlation Analysis: Indoor vs Outdoor', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Cross Correlation Analysis for Indoor Versus Outdoor Trends', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'correlation_analysis.png');
 close(fig);
 end

--- a/plot_cost_per_aqi_hour.m
+++ b/plot_cost_per_aqi_hour.m
@@ -108,7 +108,7 @@ end
 % Formatting
 set(gca, 'XTick', x, 'XTickLabel', modes);
 ylabel('Cost per AQI Hour Avoided ($)');
-title('Cost Effectiveness Comparison with Uncertainty Bounds');
+title('Cost Effectiveness Comparison with Uncertainty Ranges');
 legend(barHandles, filters, 'Location', 'best');
 grid on;
 

--- a/plot_cost_vs_aqi_avoided.m
+++ b/plot_cost_vs_aqi_avoided.m
@@ -70,7 +70,7 @@ end
 
 xlabel('AQI Hours Avoided');
 ylabel('Total Operational Cost ($)');
-title('Cost vs. AQI Exposure Avoided (with Scenario Bounds)');
+title('Cost Versus Air Quality Index Exposure Avoided with Scenario Bounds');
 grid on;
 legend('Location', 'eastoutside');
 

--- a/plot_cumulative_exposure.m
+++ b/plot_cumulative_exposure.m
@@ -65,7 +65,8 @@ for i = 1:height(uniqueConfigs)
         legendEntries{end+1} = sprintf('%s Range', modeName);
         legendEntries{end+1} = sprintf('%s Mean', modeName);
     end
-    title(sprintf('%s - %s', loc, filt));
+    title(sprintf('Cumulative Exposure for %s with %s Filter', ...
+        strrep(loc, '_', ' '), strrep(filt, '_', ' ')));
     xlabel('Hour of Year');
     if isempty(envLabel)
         ylabel(sprintf('Cumulative %s Exposure (µg/m³·h)', pmLabel));
@@ -76,12 +77,26 @@ for i = 1:height(uniqueConfigs)
     grid on;
 end
 
+readablePmLabel = expand_pm_label(pmLabel);
 if isempty(envLabel)
-    sgTxt = sprintf('Cumulative %s Exposure Over Time', pmLabel);
+    sgTxt = sprintf('Cumulative %s Exposure Over Time', readablePmLabel);
 else
-    sgTxt = sprintf('Cumulative %s %s Exposure Over Time', envLabel, pmLabel);
+    sgTxt = sprintf('Cumulative %s %s Exposure Over Time', envLabel, readablePmLabel);
 end
 sgtitle(sgTxt);
 save_figure(fig, figuresDir, fileName);
 close(fig);
+end
+
+function readable = expand_pm_label(label)
+%EXPAND_PM_LABEL Provide a descriptive particulate matter label for titles.
+
+switch lower(label)
+    case {'pm2.5', 'pm25', 'pm_25'}
+        readable = 'Fine Particulate Matter Under 2.5 Micrometers';
+    case {'pm10', 'pm_10'}
+        readable = 'Coarse Particulate Matter Under 10 Micrometers';
+    otherwise
+        readable = strrep(label, '_', ' ');
+end
 end

--- a/plot_deterministic_bounds.m
+++ b/plot_deterministic_bounds.m
@@ -84,7 +84,7 @@ end
 
 set(gca, 'XTick', 1:nMetrics, 'XTickLabel', metricLabels);
 ylabel('Normalized Value');
-title('Physical Bounds: Tight (solid) vs Leaky (dashed) Building Envelopes');
+title('Physical Bounds for Tight and Leaky Building Envelopes');
 ylim([0 1]);
 grid on;
 
@@ -223,9 +223,10 @@ if ~isempty(exampleIdx)
         ylabel('Bounds Width (µg/m³)');
 
         xlabel('Hour');
-        title(sprintf('Physical Bounds Evolution: %s %s %s (First Week)', ...
-            scenarios.location{exampleIdx}, scenarios.filterType{exampleIdx}, ...
-            scenarios.mode{exampleIdx}));
+        title(sprintf('Physical Bounds Evolution for %s %s %s During First Week', ...
+            strrep(scenarios.location{exampleIdx}, '_', ' '), ...
+            strrep(scenarios.filterType{exampleIdx}, '_', ' '), ...
+            strrep(scenarios.mode{exampleIdx}, '_', ' ')));
         legend({'Operating Envelope', 'Tight', 'Leaky', 'Bounds Width'}, ...
             'Location','eastoutside');
         grid on;
@@ -233,7 +234,7 @@ if ~isempty(exampleIdx)
 end
 
 % Overall title
-sgtitle('Deterministic Physical Bounds Analysis: Building Envelope Performance', ...
+sgtitle('Deterministic Physical Bounds Analysis of Building Envelope Performance', ...
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Save

--- a/plot_dynamic_filter_comparison.m
+++ b/plot_dynamic_filter_comparison.m
@@ -83,7 +83,7 @@ for loc_idx = 1:length(locations)
     set(gca, 'XTick', x, 'XTickLabel', metric_labels);
     xtickangle(45);
     ylabel('Normalized Score');
-    title(sprintf('%s - Filter Comparison', location));
+    title(sprintf('Filter Comparison for %s', strrep(location, '_', ' ')));
     legend([hHepa hMerv], {'HEPA', 'MERV'}, 'Location', 'best');
     grid on;
 end
@@ -92,7 +92,7 @@ end
 subplot(2, 2, [3 4]);
 plot_filter_radar_comparison(filterComparison);
 
-sgtitle('Dynamic Filter Performance Comparison - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Dynamic Filter Performance Comparison During Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'filter_comparison_dynamic.png');
 close(fig);
 end
@@ -189,5 +189,5 @@ hRangeMerv = patch(ax, NaN, NaN, [0.8 0.3 0.3], 'FaceAlpha', 0.1, 'EdgeColor', '
 legend(ax, [hPolarHepa hPolarMerv hRangeHepa hRangeMerv], ...
     {'HEPA mean', 'MERV mean', 'HEPA tight–leaky', 'MERV tight–leaky'}, ...
     'Location', 'southoutside');
-title(ax, 'Multi-Criteria Filter Comparison');
+title(ax, 'Filter Comparison Across Multiple Criteria');
 end

--- a/plot_efficacy_scores.m
+++ b/plot_efficacy_scores.m
@@ -50,7 +50,7 @@ errorbar(1:nConfigs, efficacyScoreTable.mean_efficacy_score, ...
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', scenarioLabels);
 xtickangle(45);
 ylabel('Composite Efficacy Score (0-100)');
-title('Overall Efficacy Ranking');
+title('Overall Intervention Efficacy Ranking');
 grid on;
 ylim([0 100]);
 
@@ -72,7 +72,7 @@ bar(componentData, 'stacked');
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', scenarioLabels);
 xtickangle(45);
 ylabel('Component Score Contribution');
-title('Efficacy Component Breakdown');
+title('Efficacy Component Breakdown by Metric');
 legend({'PM2.5 (40%)', 'PM10 (20%)', 'Cost Eff. (20%)', 'AQI Hours (20%)'}, ...
     'Location', 'eastoutside');
 grid on;
@@ -92,7 +92,7 @@ bar(1:nConfigs, efficacyScoreTable.leaky_efficacy_score, ...
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', scenarioLabels);
 xtickangle(45);
 ylabel('Efficacy Score');
-title('Building Envelope Comparison');
+title('Building Envelope Performance Comparison');
 legend('Location', 'eastoutside');
 grid on;
 
@@ -102,7 +102,7 @@ bar(efficacyScoreTable.score_range, 'FaceColor', cmap.gray, 'EdgeColor', 'k');
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', scenarioLabels);
 xtickangle(45);
 ylabel('Score Range (Tight - Leaky)');
-title('Performance Uncertainty');
+title('Performance Uncertainty Range');
 grid on;
 
 % Add threshold line for "high uncertainty"
@@ -118,7 +118,7 @@ ylabel(cb, 'Overall Efficacy Score');
 
 xlabel('PM2.5 Component Score');
 ylabel('Cost Effectiveness Component Score');
-title('PM2.5 vs Cost Trade-off');
+title('Fine Particulate Matter Reduction Versus Cost Tradeoff');
 grid on;
 
 % Add scenario labels
@@ -145,7 +145,7 @@ ylabel(cb, 'Component Score');
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', scenarioLabels);
 set(gca, 'YTick', 1:4, 'YTickLabel', {'PM2.5', 'PM10', 'Cost', 'AQI'});
 xtickangle(45);
-title('Performance Heatmap');
+title('Performance Heatmap Across Configurations');
 
 % Add text annotations
 for i = 1:size(heatmapData,1)
@@ -156,7 +156,7 @@ for i = 1:size(heatmapData,1)
 end
 
 % Overall title
-sgtitle('Composite Efficacy Score Analysis: Multi-Criteria Performance Evaluation', ...
+sgtitle('Composite Efficacy Score Analysis with Multiple Performance Criteria', ...
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Save
@@ -251,7 +251,7 @@ for rowIdx = 1:nDisplayRows
     end
 end
 
-title(ax, 'Efficacy Score Rankings: Top Performing Configurations', ...
+title(ax, 'Efficacy Score Rankings for Top Performing Configurations', ...
     'FontSize', 14, 'FontWeight', 'bold');
 
 hold(ax, 'off');

--- a/plot_efficiency_cost_quadrant.m
+++ b/plot_efficiency_cost_quadrant.m
@@ -70,7 +70,7 @@ text(x_median*1.5, y_median*1.5, 'High Cost, High Reduction', ...
 
 xlabel('% Indoor PM2.5 Reduction from Baseline');
 ylabel('Total Operational Cost ($)');
-title('Cost vs. Indoor PM2.5 Reduction Quadrant Map (with Uncertainty Regions)');
+title('Cost Versus Indoor Fine Particulate Matter Reduction with Uncertainty Regions');
 grid on;
 legend('Location', 'eastoutside');
 

--- a/plot_efficiency_cost_quadrant_pm10.m
+++ b/plot_efficiency_cost_quadrant_pm10.m
@@ -58,7 +58,7 @@ set(hY, 'DisplayName', 'Median Cost');
 
 xlabel('% Indoor PM10 Reduction from Baseline');
 ylabel('Total Operational Cost ($)');
-title('Cost vs. Indoor PM10 Reduction Quadrant Map (with Uncertainty Regions)');
+title('Cost Versus Indoor Coarse Particulate Matter Under 10 Micrometers Reduction with Uncertainty Regions');
 grid on;
 legend('Location', 'eastoutside');
 

--- a/plot_envelope_sensitivity.m
+++ b/plot_envelope_sensitivity.m
@@ -201,7 +201,7 @@ end
 barh(sortedSens);
 set(gca, 'YTick', 1:length(metrics), 'YTickLabel', metricLabels(sortIdx));
 xlabel('Mean Sensitivity (normalized)');
-title('Tornado Diagram: Parameter Sensitivity');
+title('Parameter Sensitivity Ranking');
 grid on;
 
 % Add note about mixed methods
@@ -236,7 +236,7 @@ end
 
 xlabel('Scenario');
 ylabel('Sensitivity (% change or absolute*)');
-title('Envelope Sensitivity by Scenario');
+title('Envelope Sensitivity Across Scenarios');
 legend({'PM2.5','Cost','Filter Life'}, 'Location','eastoutside');
 set(gca, 'XTick', x, 'XTickLabel', scenarioLabels);
 xtickangle(45);
@@ -253,7 +253,7 @@ scatter(sensitivity.cost_sensitivity(validIdx), ...
 
 xlabel('Cost Increase (%)');
 ylabel('Effectiveness Change (% points)');
-title('Cost vs Effectiveness Trade-off Impact');
+title('Cost Impact Versus Effectiveness Change');
 colormap(lines(sum(validIdx)));
 
 % Add quadrant lines
@@ -294,12 +294,12 @@ set(gca, 'XTick', 1:height(sensitivity));
 set(gca, 'XTickLabel', scenarioLabels);
 ylabel('Number of Metrics');
 legend(method_labels, 'Location', 'best');
-title('Calculation Methods Used');
+title('Distribution of Calculation Methods Across Metrics');
 xtickangle(45);
 grid on;
 
 % Overall title
-sgtitle('Building Envelope Sensitivity Analysis: Impact of Leakage on System Performance (Enhanced)', ...
+sgtitle('Building Envelope Sensitivity Analysis for Leakage Impact on System Performance', ...
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Save

--- a/plot_event_metric_distributions.m
+++ b/plot_event_metric_distributions.m
@@ -37,7 +37,7 @@ for m = 1:numel(metrics)
     set(gca,'XTick',1:numel(grpLabels),'XTickLabel',grpLabels);
     xtickangle(45);
     ylabel(labels{m});
-    title(sprintf('Distribution of %s', strrep(metric,'_',' ')));
+    title(sprintf('Distribution of %s Values', strrep(metric,'_',' ')));
     grid on;
 
     % ECDF
@@ -52,7 +52,7 @@ for m = 1:numel(metrics)
     end
     xlabel(labels{m});
     ylabel('ECDF');
-    title(sprintf('ECDF of %s', strrep(metric,'_',' ')));
+    title(sprintf('Empirical Cumulative Distribution of %s', strrep(metric,'_',' ')));
     legend('Location','best');
     grid on;
 

--- a/plot_event_response_analysis.m
+++ b/plot_event_response_analysis.m
@@ -62,7 +62,7 @@ text(0.02,0.98,'Error bars show tight/leaky bounds', 'Units','normalized', ...
 
 set(gca, 'XTick', 1:length(configs), 'XTickLabel', labels);
 xtickangle(45);
-title('Pollution Event Statistics');
+title('Pollution Event Summary Statistics');
 grid on;
 
 
@@ -111,7 +111,7 @@ end
 
 xlabel('Peak Reduction (%)');
 ylabel('Integrated Reduction (%)');
-title('Event Response Effectiveness');
+title('Effectiveness of Event Responses');
 grid on;
 legend('Location','best');
 
@@ -144,7 +144,7 @@ xlim([0 length(configs)+1]);
 set(gca, 'XTick', 1:length(configs), 'XTickLabel', labels);
 xtickangle(45);
 ylabel('Peak/Baseline Ratio');
-title('Distribution of Event Severities');
+title('Distribution of Event Severity Levels');
 legend({'Tight','Leaky'}, 'Location', 'best');
 grid on;
 
@@ -153,7 +153,7 @@ subplot(2, 3, [4 6]);
 % Plot example responses for most severe events
 plot_example_event_responses(eventAnalysis);
 
-sgtitle('Pollution Event Response Analysis - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Pollution Event Response Analysis During Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'event_response_analysis.png');
 close(fig);
 end
@@ -214,7 +214,7 @@ end
 
 xlabel('Event Index');
 ylabel('Peak Reduction (%)');
-title('Event Response Metrics by Event');
+title('Event Response Metrics by Occurrence');
 % Filter out any invalid handles in case some configs lacked data
 valid = isgraphics(legendHandles);
 if any(valid)

--- a/plot_executive_summary.m
+++ b/plot_executive_summary.m
@@ -91,7 +91,7 @@ else
     end
 
     ylabel('Value');
-    title('Bakersfield – Active Intervention');
+    title('Active Intervention Results for Bakersfield');
     grid on;
 end
 
@@ -140,7 +140,7 @@ yline(yMed, '--k', 'Median Cost');
 
 xlabel('PM2.5 Reduction (%)');
 ylabel('Annual Cost ($)');
-title('Cost-Effectiveness with Uncertainty Regions');
+title('Cost and Effectiveness Outcomes with Uncertainty Ranges');
 grid on;
 legend('Location', 'eastoutside');
 
@@ -177,7 +177,7 @@ end
 set(gca, 'XTick', positions, 'XTickLabel', filterTypes);
 xlabel('Filter Type');
 ylabel('PM2.5 Reduction (%)');
-title('Performance Distribution by Filter Type');
+title('Performance Distribution Across Filter Types');
 grid on;
 legend(unique(get(gca,'Children')),'Location','bestoutside');
 
@@ -211,7 +211,7 @@ if length(performance) > 2
 end
 xlabel('Mean PM2.5 Reduction (%)');
 ylabel('Uncertainty Range (% points)');
-title('Performance vs. Uncertainty');
+title('Performance Versus Uncertainty Range');
 grid on;
 
 %% Panel 5: Top Interventions Table
@@ -322,7 +322,7 @@ text(0.5, 0.05, 'Score = 0.5×(PM2.5 reduction) + 0.3×(cost efficiency) + 0.2×
     'HorizontalAlignment', 'center', 'FontSize', 8, 'FontAngle', 'italic');
 
 % Overall title
-sgtitle('Executive Summary: Intervention Performance with Uncertainty', ...
+sgtitle('Executive Summary of Intervention Performance with Uncertainty Ranges', ...
     'FontSize', 16, 'FontWeight', 'bold');
 
 save_figure(fig, figuresDir, 'executive_summary_with_bounds.png');

--- a/plot_filter_life_envelope.m
+++ b/plot_filter_life_envelope.m
@@ -132,7 +132,9 @@ for i = 1:nConfigs
     ylim([0 105]);
     xlabel('Hour of Simulation');
     ylabel('Filter Life (%)');
-    title(sprintf('%s - %s - %s', loc, filt, mode), 'Interpreter', 'none');
+    title(sprintf('Filter Life Envelope for %s %s %s', ...
+        strrep(loc,'_',' '), strrep(filt,'_',' '), strrep(mode,'_',' ')), ...
+        'Interpreter', 'none');
     grid on;
 
     % Add statistics box
@@ -148,7 +150,7 @@ for i = 1:nConfigs
 end
 
 % Add overall title
-sgtitle('Filter Life Degradation: Building Envelope Bounds', ...
+sgtitle('Filter Life Degradation Across Building Envelope Bounds', ...
     'FontSize', 14, 'FontWeight', 'bold');
 
 % Add general note

--- a/plot_filter_replacement.m
+++ b/plot_filter_replacement.m
@@ -93,7 +93,7 @@ end
 
 set(gca, 'XTick', x, 'XTickLabel', modes);
 ylabel('Filter Replacements per Year');
-title('Annual Filter Replacement Frequency');
+title('Annual Filter Replacement Frequency by Operating Mode');
 legend(filters, 'Location', 'northwest');
 grid on;
 % Determine y-axis limits while safely handling missing data
@@ -126,7 +126,7 @@ end
 bar(relativeRange', 'grouped');
 set(gca, 'XTick', 1:nFilters, 'XTickLabel', filters);
 ylabel('Relative Range (%)');
-title('Replacement Frequency Range');
+title('Replacement Frequency Range by Filter Type');
 legend(modes, 'Location', 'best');
 grid on;
 
@@ -136,7 +136,7 @@ text(0.5, -0.15, 'Wider range indicates greater sensitivity to building envelope
     'FontSize', 9, 'FontAngle', 'italic');
 
 % Overall title
-sgtitle('Filter Replacement Analysis with Building Envelope Bounds', ...
+sgtitle('Filter Replacement Analysis Across Building Envelope Scenarios', ...
     'FontSize', 14, 'FontWeight', 'bold');
 
 save_figure(fig, figuresDir, 'filter_replacement_with_bounds.png');

--- a/plot_intervention_efficacy_dashboard.m
+++ b/plot_intervention_efficacy_dashboard.m
@@ -25,7 +25,7 @@ colorTriggered = [0.9 0.6 0.2];
 colorAlwaysOn = [0.3 0.7 0.3];
 
 % Super title
-sgtitle('Air Quality Intervention Efficacy Dashboard', 'FontSize', 18, 'FontWeight', 'bold');
+sgtitle('Air Quality Intervention Efficacy Dashboard Overview', 'FontSize', 18, 'FontWeight', 'bold');
 
 %% Panel 1: PM2.5 Reduction Efficacy by Intervention
 subplot(2,3,1)
@@ -65,6 +65,8 @@ end
 function plotReductionEfficacy(costTable, pollutant)
     % Extract data for non-baseline scenarios
     data = costTable(~strcmp(costTable.mode, 'baseline'), :);
+
+    readablePollutant = format_pollutant_label(pollutant);
     
     % Group by location and filter type
     locations = unique(data.location);
@@ -144,8 +146,8 @@ function plotReductionEfficacy(costTable, pollutant)
     
     % Customize appearance
     set(gca, 'XTick', 1:length(labels), 'XTickLabel', labels);
-    ylabel(sprintf('%s Reduction (%%)' , pollutant));
-    title(sprintf('%s Reduction Efficacy', pollutant), 'FontWeight', 'bold');
+    ylabel(sprintf('%s Reduction (%%)', readablePollutant));
+    title(sprintf('%s Reduction Efficacy', readablePollutant), 'FontWeight', 'bold');
     legend(modes, 'Location', 'best', 'Interpreter', 'none');
     grid on;
     ylim([0 max(dataMatrix(:) + errorMatrix(:)) * 1.1]);
@@ -213,7 +215,7 @@ function plotScenarioBounds(costTable, summaryTable)
     
     set(gca, 'YTick', y, 'YTickLabel', configLabels(sortIdx));
     xlabel('PM2.5 Reduction (%)');
-    title('Efficacy Bounds: Tight vs Leaky Homes', 'FontWeight', 'bold');
+    title('Efficacy Bounds Across Tight and Leaky Homes', 'FontWeight', 'bold');
     grid on;
     xlim([0, max(boundsData(:,3)) * 1.1]);
 end
@@ -269,7 +271,7 @@ function plotCostEffectivenessBubble(costTable)
     
     xlabel('PM2.5 Reduction (%)');
     ylabel('Cost per μg/m³ Removed ($)');
-    title('Cost-Effectiveness Analysis', 'FontWeight', 'bold');
+    title('Cost Effectiveness Analysis Across Configurations', 'FontWeight', 'bold');
     
     % Add legend for bubble size
     text(min(x), max(y)*0.8, 'Bubble size = AQI hours avoided', ...
@@ -344,7 +346,7 @@ function plotCumulativeBenefit(summaryTable)
     
     xlabel('Hours');
     ylabel('Cumulative PM2.5 Reduction (μg/m³·h)');
-    title('Cumulative Exposure Benefit (First Week)', 'FontWeight', 'bold');
+    title('Cumulative Exposure Benefit During First Week', 'FontWeight', 'bold');
     legend('Location', 'best', 'Interpreter', 'none');
     grid on;
     
@@ -403,7 +405,7 @@ function plotBuildingEnvelopeSensitivity(costTable)
     
     set(gca, 'YTick', x, 'YTickLabel', labels(sortIdx));
     xlabel('Relative Sensitivity to Building Envelope (%)');
-    title('Building Envelope Impact on Performance', 'FontWeight', 'bold');
+    title('Building Envelope Impact on Performance Metrics', 'FontWeight', 'bold');
     
     % Add center line
     xline(0, 'k', 'LineWidth', 1);
@@ -521,4 +523,17 @@ function plotEfficacyScorecard(costTable, healthExposureTable)
     
     xlim([0 1]);
     ylim([0 1]);
+end
+
+function label = format_pollutant_label(pollutant)
+%FORMAT_POLLUTANT_LABEL Provide descriptive pollutant labels for titles.
+
+switch lower(pollutant)
+    case {'pm2.5', 'pm25', 'pm_25'}
+        label = 'Fine Particulate Matter Under 2.5 Micrometers';
+    case {'pm10', 'pm_10'}
+        label = 'Coarse Particulate Matter Under 10 Micrometers';
+    otherwise
+        label = strrep(pollutant, '_', ' ');
+end
 end

--- a/plot_intervention_matrix.m
+++ b/plot_intervention_matrix.m
@@ -11,6 +11,8 @@ if nargin < 2 || isempty(pollutant)
     pollutant = 'PM25';
 end
 
+readablePollutant = format_pollutant_label(pollutant);
+
 % Get unique configurations (no leakage grouping)
 locations = unique(costTable.location);
 filterTypes = unique(costTable.filterType(~strcmp(costTable.filterType, 'baseline')));
@@ -104,14 +106,14 @@ if ~isfinite(vmin) || ~isfinite(vmax) || vmin == vmax
 end
 caxis(ax1, [vmin vmax]);
 cb = colorbar(ax1);
-ylabel(cb, sprintf('%s Reduction (%%) - Mean Value', pollutant));
+ylabel(cb, sprintf('%s Reduction (%%) Mean Value', readablePollutant));
 
 % Set labels
 set(ax1, 'XTick', 1:nInt, 'XTickLabel', interventions);
 set(ax1, 'YTick', 1:nLoc, 'YTickLabel', locations);
 xlabel(ax1, 'Intervention Type');
 ylabel(ax1, 'Location');
-title(ax1, sprintf('%s Reduction Efficacy Matrix with Uncertainty', pollutant));
+title(ax1, sprintf('%s Reduction Efficacy Matrix with Uncertainty', readablePollutant));
 
 % Add text annotations with uncertainty
 for l = 1:nLoc
@@ -164,4 +166,17 @@ text(ax1, 0.02, 0.02, 'Range bars span tight (left) to leaky (right) outcomes', 
 
 save_figure(fig, figuresDir, sprintf('intervention_matrix_%s_with_uncertainty.png', lower(pollutant)));
 close(fig);
+end
+
+function label = format_pollutant_label(pollutant)
+%FORMAT_POLLUTANT_LABEL Create descriptive pollutant labels for titles.
+
+switch lower(pollutant)
+    case {'pm2.5', 'pm25', 'pm_25'}
+        label = 'Fine Particulate Matter Under 2.5 Micrometers';
+    case {'pm10', 'pm_10'}
+        label = 'Coarse Particulate Matter Under 10 Micrometers';
+    otherwise
+        label = strrep(pollutant, '_', ' ');
+end
 end

--- a/plot_io_ratio_dynamics.m
+++ b/plot_io_ratio_dynamics.m
@@ -38,13 +38,14 @@ for i = 1:nConfigs
     
     xlabel('Hour');
     ylabel('Indoor/Outdoor Ratio');
-    title(sprintf('%s - %s Filter', data.location, data.filterType));
+    title(sprintf('Indoor to Outdoor Ratio Dynamics for %s with %s Filter', ...
+        strrep(data.location, '_', ' '), strrep(data.filterType, '_', ' ')));
     legend({'PM2.5 Bounds', 'PM2.5 Mean', 'PM10 Bounds', 'PM10 Mean'}, 'Location', 'best');
     grid on;
     ylim([0 1.5]);
 end
 
-sgtitle('Indoor/Outdoor Ratio Dynamics - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Indoor to Outdoor Ratio Dynamics During Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'io_ratio_dynamics.png');
 close(fig);
 end

--- a/plot_penetration_analysis.m
+++ b/plot_penetration_analysis.m
@@ -56,7 +56,7 @@ errorbar(x + width/2, pm10_factors, ...
 set(gca, 'XTick', x, 'XTickLabel', labels);
 ylabel('Penetration Factor');
 legend([hPM25 hPM10], {'PM2.5', 'PM10'}, 'Location', 'best');
-title('Particle Penetration Factors');
+title('Particle Penetration Factors by Configuration');
 grid on;
 ylim([0 1]);
 
@@ -86,7 +86,7 @@ errorbar(x + width/2, pm10_removal, ...
 set(gca, 'XTick', x, 'XTickLabel', labels);
 ylabel('Removal Efficiency (%)');
 legend([hR25 hR10], {'PM2.5', 'PM10'}, 'Location', 'best');
-title('Particle Removal Efficiency');
+title('Particle Removal Efficiency by Configuration');
 grid on;
 
 % Size-dependent efficiency ratio
@@ -103,7 +103,7 @@ errorbar(x, size_ratio, ...
 
 set(gca, 'XTick', x, 'XTickLabel', labels);
 ylabel('PM10/PM2.5 Penetration Ratio');
-title('Size-Dependent Penetration');
+title('Size Dependent Penetration Ratio');
 yline(1, '--k', 'Equal Penetration');
 grid on;
 
@@ -135,12 +135,12 @@ if isfield(data, 'hourly_penetration_pm25')
     plot(t, data.hourly_penetration_pm10(t), 'r-', 'LineWidth', 1.5);
     xlabel('Hour');
     ylabel('Penetration Factor');
-    title(sprintf('Temporal Variation - %s', config));
+    title(sprintf('Penetration Temporal Variation for %s', strrep(config, '_', ' ')));
     legend({'PM2.5 Bounds', 'PM10 Bounds', 'PM2.5 Mean', 'PM10 Mean'}, 'Location', 'best');
     grid on;
 end
 
-sgtitle('Particle Penetration Analysis - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Particle Penetration Analysis During Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'penetration_analysis.png');
 close(fig);
 end

--- a/plot_pm_envelope.m
+++ b/plot_pm_envelope.m
@@ -15,6 +15,8 @@ elseif contains(lower(pmField), 'outdoor')
     envLabel = 'Outdoor';
 end
 
+readablePmLabel = expand_pm_label(pmLabel);
+
 configs = unique(summaryTable(:, {'location','filterType'}));
 
 for i = 1:height(configs)
@@ -119,7 +121,8 @@ for i = 1:height(configs)
     else
         ylabel(sprintf('%s %s Concentration (µg/m³)', envLabel, pmLabel));
     end
-    title(sprintf('%s - %s: Hourly Concentration Bounds', loc, filt));
+    title(sprintf('Hourly Concentration Bounds for %s with %s Filter', ...
+        strrep(loc, '_', ' '), strrep(filt, '_', ' ')));
     legend(legendEntries, 'Location', 'best');
     grid on;
     xlim([1 length(t)]);
@@ -225,15 +228,19 @@ for i = 1:height(configs)
 
     xlabel('Hour of Year');
     ylabel('Relative Bounds Width (%)');
-    title('Range Over Time');
+    title('Concentration Range Over Time');
     legend(modes, 'Location','eastoutside');
     grid on;
 
     % Overall title
+    cleanLoc = strrep(loc, '_', ' ');
+    cleanFilt = strrep(filt, '_', ' ');
     if isempty(envLabel)
-        sgTitle = sprintf('Comprehensive %s Analysis: %s - %s Filter', pmLabel, loc, filt);
+        sgTitle = sprintf('Comprehensive %s Analysis for %s with %s Filter', ...
+            readablePmLabel, cleanLoc, cleanFilt);
     else
-        sgTitle = sprintf('Comprehensive %s %s Analysis: %s - %s Filter', envLabel, pmLabel, loc, filt);
+        sgTitle = sprintf('Comprehensive %s %s Analysis for %s with %s Filter', ...
+            envLabel, readablePmLabel, cleanLoc, cleanFilt);
     end
     sgtitle(sgTitle, 'FontSize',14,'FontWeight','bold');
     % Save
@@ -248,5 +255,20 @@ for i = 1:height(configs)
     fname = sprintf('%s_%s_%s_enhanced.png', prefix, locStr, filtStr);
     save_figure(fig, figuresDir, fullfile(locStr, filtStr), fname);
     close(fig);
+end
+
+end
+
+function readable = expand_pm_label(label)
+%EXPAND_PM_LABEL Provide descriptive particulate matter labels for titles.
+
+switch lower(label)
+    case {'pm2.5', 'pm25', 'pm_25'}
+        readable = 'Fine Particulate Matter Under 2.5 Micrometers';
+    case {'pm10', 'pm_10'}
+        readable = 'Coarse Particulate Matter Under 10 Micrometers';
+    otherwise
+        readable = strrep(label, '_', ' ');
+end
 end
 end

--- a/plot_scalar_ranges.m
+++ b/plot_scalar_ranges.m
@@ -59,7 +59,7 @@ values = rows.mean;
 lowerBounds = rows.lower_bound;
 upperBounds = rows.upper_bound;
 yLabelText = metricName;
-titleText = sprintf('Range: %s (tight vs. leaky)', metricName);
+titleText = sprintf('Range for %s Across Tight and Leaky Envelopes', strrep(metricName, '_', ' '));
 noteText = '';
 
 if strcmp(metricName, 'filter_replaced')
@@ -108,7 +108,7 @@ if strcmp(metricName, 'filter_replaced')
     upperBounds(missingMask) = 0;
 
     yLabelText = 'Filter Replacements per Year';
-    titleText = 'Range: Filter Replacement Frequency (tight vs. leaky)';
+    titleText = 'Filter Replacement Frequency Range Across Tight and Leaky Envelopes';
     noteText = 'Derived from simulated replacement events; 0 indicates no replacements observed.';
 end
 

--- a/plot_statistical_summary.m
+++ b/plot_statistical_summary.m
@@ -79,7 +79,7 @@ end
 
 ax1.ThetaTickLabel = r_labels(1:end-1);
 ax1.RLim = [0 1];
-title(ax1, 'Normalized Scenario Ranges (Tight vs Leaky)');
+title(ax1, 'Normalized Scenario Ranges Across Tight and Leaky Envelopes');
 
 % Create legend separately
 legendAx = axes('Position', [0.45 0.65 0.1 0.25], 'Visible', 'off');
@@ -97,7 +97,7 @@ avgPerformance = 100 - summaryStats(:,5); % Convert to reduction
 scatter(avgRange, avgPerformance, 100, 1:nConfigs, 'filled');
 xlabel('Average Range (%)');
 ylabel('PM2.5 Reduction Performance');
-title('Performance vs. Range Trade-off');
+title('Performance Versus Range Tradeoff');
 colormap(lines(nConfigs));
 grid on;
 
@@ -144,7 +144,7 @@ for i = 1:size(heatmapData,1)
 end
 
 % Overall title
-sgtitle('Statistical Summary: Building Envelope Range Analysis', ...
+sgtitle('Statistical Summary of Building Envelope Range Analysis', ...
     'FontSize', 16, 'FontWeight', 'bold');
 
 % Save

--- a/plot_temporal_patterns.m
+++ b/plot_temporal_patterns.m
@@ -38,7 +38,7 @@ end
 
 xlabel('Hour of Day');
 ylabel('Average I/O Ratio');
-title('Diurnal Pattern of Filtration Performance');
+title('Diurnal Variation in Filtration Performance');
 if ~isempty(diurnalHandles)
     legend(diurnalHandles, diurnalLabels, 'Location', 'best');
 else
@@ -81,7 +81,7 @@ if any(~isnan(stab_lower))
 end
 set(gca, 'XTick', 1:length(labels), 'XTickLabel', labels);
 ylabel('Stability Score');
-title('Temporal Performance Stability');
+title('Filtration Performance Stability Over Time');
 grid on;
 
 % Performance degradation over time
@@ -114,7 +114,7 @@ end
 
 xlabel('Day');
 ylabel('Daily Average I/O Ratio');
-title('Performance Trend Over Time');
+title('Filtration Performance Trend Over Time');
 if ~isempty(lineHandles)
     legend(lineHandles, legendLabels, 'Location', 'best');
 else
@@ -122,7 +122,7 @@ else
 end
 grid on;
 
-sgtitle('Temporal Patterns in Active Mode Performance', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Temporal Patterns in Active Mode Filtration Performance', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'temporal_patterns.png');
 close(fig);
 end

--- a/plot_trigger_response_analysis.m
+++ b/plot_trigger_response_analysis.m
@@ -46,7 +46,7 @@ if ~isempty(lag_times)
     end
     xlabel('Average Lag Time (hours)');
     ylabel('Average Peak Reduction (%)');
-    title('Trigger Response Performance');
+    title('Trigger Response Performance Summary');
     grid on;
 end
 
@@ -76,7 +76,7 @@ end
 
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', labels);
 ylabel('Response Time (hours)');
-title('Average System Response Time');
+title('Average System Response Time by Configuration');
 xtickangle(45);
 grid on;
 
@@ -107,7 +107,7 @@ hInactive = bar(x + width/2, inactive_ratios, width, 'FaceColor', [0.8 0.2 0.2])
 set(gca, 'XTick', x, 'XTickLabel', labels);
 ylabel('I/O Ratio');
 legend([hActive hInactive], {'Active', 'Inactive'}, 'Location', 'best');
-title('Active vs Inactive Performance');
+title('Active and Inactive Performance Comparison');
 xtickangle(45);
 grid on;
 
@@ -146,7 +146,7 @@ else
     plot_event_timeline_example(data, config);
 end
 
-sgtitle('Trigger Response Analysis - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Trigger Response Analysis During Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'trigger_response_analysis.png');
 close(fig);
 end
@@ -198,7 +198,7 @@ errorbar(x + width/2, pm10_factors, ...
 set(gca, 'XTick', x, 'XTickLabel', labels);
 ylabel('Penetration Factor');
 legend({'PM2.5', 'PM10'}, 'Location', 'best');
-title('Particle Penetration Factors');
+title('Particle Penetration Factors by Configuration');
 grid on;
 ylim([0 1]);
 
@@ -226,7 +226,7 @@ errorbar(x + width/2, pm10_removal, ...
 set(gca, 'XTick', x, 'XTickLabel', labels);
 ylabel('Removal Efficiency (%)');
 legend({'PM2.5', 'PM10'}, 'Location', 'best');
-title('Particle Removal Efficiency');
+title('Particle Removal Efficiency by Configuration');
 grid on;
 
 % Size-dependent efficiency ratio
@@ -243,7 +243,7 @@ errorbar(x, size_ratio, ...
 
 set(gca, 'XTick', x, 'XTickLabel', labels);
 ylabel('PM10/PM2.5 Penetration Ratio');
-title('Size-Dependent Penetration');
+title('Size Dependent Penetration Ratio');
 yline(1, '--k', 'Equal Penetration');
 grid on;
 
@@ -259,12 +259,12 @@ if isfield(data, 'hourly_penetration_pm25')
     plot(t, data.hourly_penetration_pm10(t), 'r-', 'LineWidth', 1.5);
     xlabel('Hour');
     ylabel('Penetration Factor');
-    title(sprintf('Temporal Variation - %s', config));
+    title(sprintf('Penetration Temporal Variation for %s', strrep(config, '_', ' ')));
     legend({'PM2.5', 'PM10'}, 'Location', 'best');
     grid on;
 end
 
-sgtitle('Particle Penetration Analysis - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Particle Penetration Analysis During Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'penetration_analysis.png');
 close(fig);
 end
@@ -325,7 +325,7 @@ text(0.02,0.98,'Error bars show tight/leaky bounds', 'Units','normalized', ...
 
 set(gca, 'XTick', 1:length(configs), 'XTickLabel', labels);
 xtickangle(45);
-title('Pollution Event Statistics');
+title('Pollution Event Summary Statistics');
 grid on;
 
 % Response effectiveness scatter
@@ -348,7 +348,7 @@ end
 scatter(peak_reductions, integrated_reductions, 100, 1:length(configs), 'filled');
 xlabel('Peak Reduction (%)');
 ylabel('Integrated Reduction (%)');
-title('Event Response Effectiveness');
+title('Effectiveness of Event Responses');
 colormap(lines(length(configs)));
 grid on;
 
@@ -381,7 +381,7 @@ xlim([0 length(configs)+1]);
 set(gca, 'XTick', 1:length(configs), 'XTickLabel', labels);
 xtickangle(45);
 ylabel('Peak/Baseline Ratio');
-title('Distribution of Event Severities');
+title('Distribution of Event Severity Levels');
 legend({'Tight','Leaky'}, 'Location', 'best');
 grid on;
 
@@ -390,7 +390,7 @@ subplot(2, 3, [4 6]);
 % Plot example responses for most severe events
 plot_example_event_responses(eventAnalysis);
 
-sgtitle('Pollution Event Response Analysis - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Pollution Event Response Analysis During Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'event_response_analysis.png');
 close(fig);
 end
@@ -418,7 +418,7 @@ end
 
 xlabel('Hour of Day');
 ylabel('Average I/O Ratio');
-title('Diurnal Pattern of Filtration Performance');
+title('Diurnal Variation in Filtration Performance');
 legend(strrep(configs, '_', ' '), 'Location', 'best');
 grid on;
 xlim([-0.5 23.5]);
@@ -443,7 +443,7 @@ end
 bar(stability_scores, 'FaceColor', [0.4 0.6 0.8]);
 set(gca, 'XTick', 1:length(labels), 'XTickLabel', labels);
 ylabel('Stability Score');
-title('Temporal Performance Stability');
+title('Filtration Performance Stability Over Time');
 grid on;
 
 % Performance degradation over time
@@ -462,11 +462,11 @@ end
 
 xlabel('Day');
 ylabel('Daily Average I/O Ratio');
-title('Performance Trend Over Time');
+title('Filtration Performance Trend Over Time');
 legend(strrep(configs, '_', ' '), 'Location', 'best');
 grid on;
 
-sgtitle('Temporal Patterns in Active Mode Performance', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Temporal Patterns in Active Mode Filtration Performance', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'temporal_patterns.png');
 close(fig);
 end
@@ -503,7 +503,7 @@ for i = 1:nConfigs
         
         xlabel('Lag (hours)');
         ylabel('Cross-Correlation');
-        title(sprintf('%s\nOptimal Lag: PM2.5=%dh, PM10=%dh', ...
+        title(sprintf('%s\nOptimal Lag Fine Particulate Matter 2.5 Micrometers = %dh, Coarse Particulate Matter 10 Micrometers = %dh', ...
             strrep(config, '_', ' '), ...
             data.lags(max_idx_pm25), data.lags(max_idx_pm10)));
         legend({'PM2.5', 'PM10'}, 'Location', 'best');
@@ -512,7 +512,7 @@ for i = 1:nConfigs
     end
 end
 
-sgtitle('Cross-Correlation Analysis: Indoor vs Outdoor', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Cross Correlation Analysis for Indoor Versus Outdoor Trends', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'correlation_analysis.png');
 close(fig);
 end
@@ -564,7 +564,7 @@ for loc_idx = 1:length(locations)
     set(gca, 'XTick', x, 'XTickLabel', metric_labels);
     xtickangle(45);
     ylabel('Normalized Score');
-    title(sprintf('%s - Filter Comparison', location));
+    title(sprintf('Filter Comparison for %s', strrep(location, '_', ' ')));
     legend({'HEPA', 'MERV'}, 'Location', 'best');
     grid on;
 end
@@ -573,7 +573,7 @@ end
 subplot(2, 2, [3 4]);
 plot_filter_radar_comparison(filterComparison);
 
-sgtitle('Dynamic Filter Performance Comparison - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Dynamic Filter Performance Comparison During Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'filter_comparison_dynamic.png');
 close(fig);
 end
@@ -608,7 +608,7 @@ set(gca, 'XTick', x, 'XTickLabel', labels);
 xtickangle(45);
 ylabel('Uncertainty Range (%)');
 legend({'PM2.5', 'PM10'}, 'Location', 'best');
-title('Building Envelope Uncertainty');
+title('Building Envelope Uncertainty Range by Configuration');
 grid on;
 
 % Confidence intervals over time
@@ -628,7 +628,7 @@ if isfield(data, 'hourly_ci_pm25')
     
     xlabel('Hour');
     ylabel('Indoor PM2.5 (μg/m³)');
-    title(sprintf('Confidence Intervals - %s', config));
+    title(sprintf('Confidence Intervals for %s', strrep(config, '_', ' ')));
     legend({'Envelope Bounds', 'Mean'}, 'Location', 'best');
     grid on;
 end
@@ -653,7 +653,7 @@ if ~isempty(contribution_data)
     xtickangle(45);
     ylabel('Contribution to Total Uncertainty (%)');
     legend(contribution_labels, 'Location', 'best');
-    title('Uncertainty Source Analysis');
+    title('Uncertainty Source Contribution Analysis');
     grid on;
 end
 
@@ -661,7 +661,7 @@ end
 subplot(2, 2, 4);
 plot_sensitivity_tornado(uncertaintyAnalysis);
 
-sgtitle('Uncertainty Quantification - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Uncertainty Quantification During Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'uncertainty_analysis.png');
 close(fig);
 end
@@ -672,7 +672,7 @@ function plot_event_timeline_example(triggerData, configName)
 
 resp = triggerData.pm25_response;
 if isempty(resp) || resp.num_events == 0
-    title(sprintf('Event Timeline Example - %s', strrep(configName,'_',' ')));
+    title(sprintf('Event Timeline Example for %s', strrep(configName,'_',' ')));
     text(0.5,0.5,'No events','HorizontalAlignment','center');
     return;
 end
@@ -691,7 +691,7 @@ end
 
 xlabel('Hours Relative to Event Peak');
 ylabel('Event Index');
-title(sprintf('Event Timeline Example - %s', strrep(configName,'_',' ')));
+title(sprintf('Event Timeline Example for %s', strrep(configName,'_',' ')));
 legend({'Lag Time','Recovery'}, 'Location','best');
 grid on;
 end
@@ -700,7 +700,7 @@ function plot_event_timeline(eventTable, configName)
 %PLOT_EVENT_TIMELINE Draw lag, rise and recovery segments using event metrics
 
 if isempty(eventTable)
-    title(sprintf('Event Timeline - %s', strrep(configName,'_',' ')));
+    title(sprintf('Event Timeline for %s', strrep(configName,'_',' ')));
     text(0.5,0.5,'No events','HorizontalAlignment','center');
     return;
 end
@@ -737,7 +737,7 @@ end
     ylabel('Event Number');
     yticks(1:n);
     ylim([0 n+1]);
-    title(sprintf('Event Timeline - %s', strrep(configName,'_',' ')));
+    title(sprintf('Event Timeline for %s', strrep(configName,'_',' ')));
 legend({'Rise','Lag','Recovery'}, 'Location','best');
 grid on;
 end
@@ -794,7 +794,7 @@ end
 
 xlabel('Event Index');
 ylabel('Peak Reduction (%)');
-title('Event Response Metrics by Event');
+title('Event Response Metrics by Occurrence');
 % Filter out invalid handles before creating the legend
 valid = isgraphics(legendHandles);
 if any(valid)
@@ -851,7 +851,7 @@ ax.ThetaTick = rad2deg(theta(1:end-1));
 ax.ThetaTickLabel = metric_labels;
 ax.RLim = [0 1];
 legend(ax, {'HEPA','MERV'}, 'Location','southoutside');
-title(ax,'Multi-Criteria Filter Comparison');
+title(ax,'Filter Comparison Across Multiple Criteria');
 end
 
 function plot_sensitivity_tornado(uncertaintyAnalysis)
@@ -867,7 +867,7 @@ for i = 1:numel(configs)
 end
 
 if isempty(contrib)
-    title('Sensitivity Analysis');
+    title('Uncertainty Contribution Sensitivity Analysis');
     text(0.5,0.5,'No uncertainty data','HorizontalAlignment','center');
     return;
 end
@@ -879,6 +879,6 @@ labels = {'Building Envelope','Outdoor Variability','System Response','Measureme
 barh(sortedVals,'FaceColor',[0.4 0.6 0.8]);
 set(gca,'YTick',1:numel(order),'YTickLabel',labels(order));
 xlabel('Contribution (%)');
-title('Sensitivity Analysis');
+title('Uncertainty Contribution Sensitivity Analysis');
 grid on;
 end

--- a/plot_uncertainty_analysis.m
+++ b/plot_uncertainty_analysis.m
@@ -37,7 +37,7 @@ set(gca, 'XTick', x, 'XTickLabel', labels);
 xtickangle(45);
 ylabel('Scenario Range (%)');
 legend([h25 h10], {'PM2.5', 'PM10'}, 'Location', 'best');
-title('Building Envelope Scenario Bounds');
+title('Building Envelope Scenario Bounds Comparison');
 grid on;
 
 % Confidence intervals over time
@@ -58,7 +58,7 @@ if isfield(data, 'hourly_ci_pm25')
     xlabel('Hour');
     % Use TeX interpreter for micro symbol and superscript
     ylabel('Indoor PM2.5 (\mu g/m^3)', 'Interpreter', 'tex');
-    title(sprintf('Confidence Intervals - %s', config));
+    title(sprintf('Confidence Intervals for %s', strrep(config, '_', ' ')));
     legend({'Envelope Bounds', 'Mean'}, 'Location', 'best');
     grid on;
 end
@@ -94,7 +94,7 @@ if ~isempty(contribution_data)
     xtickangle(45);
     ylabel('Contribution to Total Range (%)');
     legend(contribution_labels, 'Location', 'best');
-    title('Scenario Bounds Source Analysis');
+    title('Scenario Bounds Source Contribution Analysis');
     grid on;
 end
 
@@ -102,7 +102,7 @@ end
 subplot(2, 2, 4);
 plot_sensitivity_tornado(uncertaintyAnalysis);
 
-sgtitle('Scenario Bounds Quantification - Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
+sgtitle('Scenario Bounds Quantification During Active Mode', 'FontSize', 14, 'FontWeight', 'bold');
 save_figure(fig, saveDir, 'uncertainty_analysis.png');
 close(fig);
 end
@@ -121,7 +121,7 @@ for i = 1:numel(configs)
 end
 
 if isempty(contrib)
-    title('Sensitivity Analysis');
+    title('Uncertainty Contribution Sensitivity Analysis');
     text(0.5,0.5,'No scenario bounds data','HorizontalAlignment','center');
     return;
 end
@@ -134,6 +134,6 @@ barh(sortedVals, 'FaceColor', [0.4 0.6 0.8]);
 set(gca,'YTick',1:numel(order),'YTickLabel',labels(order));
 set(gca,'YDir','reverse');
 xlabel('Contribution (%)');
-title('Sensitivity Analysis');
+title('Uncertainty Contribution Sensitivity Analysis');
 grid on;
 end


### PR DESCRIPTION
## Summary
- Replace generic or hyphenated plot titles with descriptive, plain English phrases across the analytics suite.
- Introduce helper utilities to expand pollutant labels so titles avoid abbreviations while remaining readable.
- Ensure dynamic titles incorporate location and filter names without underscores or dashes.

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9d355a4a083279bb3796279574d16