### PR TITLE
Clarify axis labels across visualization scripts

### DIFF
--- a/plot_airflow_penalty.m
+++ b/plot_airflow_penalty.m
@@ -85,7 +85,7 @@ yline(20, '--', 'Color', [0.8 0.4 0], 'LineWidth', 1.5);
 text(0.5, 20.5, 'Noticeable Impact (20%)', 'FontSize', 9, 'Color', [0.8 0.4 0]);
 
 set(gca, 'XTick', x, 'XTickLabel', modes);
-ylabel('Airflow Reduction (%)');
+ylabel('Airflow Reduction (Percent)');
 title('Airflow Penalty Across Filter Types and Operating Modes');
 legend(filters, 'Location', 'northwest');
 grid on;
@@ -159,7 +159,7 @@ for i = 1:length(b)
     end
 end
 set(gca, 'XTick', 1:length(locations), 'XTickLabel', locations);
-ylabel('Mean Airflow Penalty (%)');
+ylabel('Mean Airflow Penalty (Percent)');
 title('Location Specific Airflow Impact');
 legend(filters, 'Location', 'best');
 grid on;
@@ -192,7 +192,7 @@ sensitivity = real(sensitivity);
 topN = min(10, length(sortedSens));
 barh(1:topN, sortedSens(1:topN), 'FaceColor', [0.6 0.6 0.8]);
 set(gca, 'YTick', 1:topN, 'YTickLabel', configLabels(sortIdx(1:topN)));
-xlabel('Envelope Sensitivity (% variation)');
+xlabel('Envelope Sensitivity (Percent Variation)');
 title('Configurations Most Sensitive to Building Envelope');
 grid on;
 
@@ -243,8 +243,8 @@ for i = 1:height(tradeoffTable)
     text(allMeans(i), allRanges(i), labels{i}, 'VerticalAlignment','bottom', ...
         'HorizontalAlignment','center', 'FontSize', 8);
 end
-xlabel('Mean Airflow Penalty (%)');
-ylabel('Uncertainty Range (% points)');
+xlabel('Mean Airflow Penalty (Percent)');
+ylabel('Uncertainty Range (Percentage Points)');
 title('Airflow Penalty Versus Uncertainty Range');
 grid on;
 

--- a/plot_aqi_stacked_bars.m
+++ b/plot_aqi_stacked_bars.m
@@ -175,7 +175,7 @@ for i = 1:height(configs)
     % Format axes
     set(gca, 'XTick', 1:numel(scenarios), 'XTickLabel', cellstr(scenarios), ...
         'FontSize', 10);
-    ylabel('Hours', 'FontSize', 11);
+    ylabel('Exposure Time in Hours', 'FontSize', 11);
     
     % Clean title formatting
     titleStr = sprintf('Air Quality Exposure for %s with %s Filter', ...

--- a/plot_aqi_time_avoided.m
+++ b/plot_aqi_time_avoided.m
@@ -98,7 +98,7 @@ for i = 1:height(configs)
     end
 
     set(gca,'XTick',1:numel(scenarios),'XTickLabel',cellstr(scenarios));
-    ylabel('Hours Avoided');
+    ylabel('Hours of Exposure Avoided');
     title(sprintf('Avoided Exposure for %s with %s Filter', ...
         strrep(loc,'_',' '), strrep(filt,'_',' ')),'Interpreter','none');
     grid on;

--- a/plot_comprehensive_bounds.m
+++ b/plot_comprehensive_bounds.m
@@ -48,8 +48,8 @@ for i = 1:nConfigs
     plot(costMean(i), i, 'o', 'MarkerFaceColor',colors(i,:), 'MarkerEdgeColor','k');
 end
 set(gca,'YTick',1:nConfigs,'YTickLabel',labels);
-ylabel('Scenario');
-xlabel('Total Cost ($)');
+ylabel('Scenario Identifier');
+xlabel('Total Cost (Dollars)');
 title('Cost Bounds Across Scenarios');
 box on; grid on;
 
@@ -60,8 +60,8 @@ for i = 1:nConfigs
     plot(pm25Mean(i), i, 'o', 'MarkerFaceColor',colors(i,:), 'MarkerEdgeColor','k');
 end
 set(gca,'YTick',1:nConfigs,'YTickLabel',labels);
-ylabel('Scenario');
-xlabel('PM2.5 Reduction (%)');
+ylabel('Scenario Identifier');
+xlabel('Particulate Matter 2.5 Reduction (Percent)');
 title('Fine Particulate Matter Reduction Bounds');
 box on; grid on;
 
@@ -72,8 +72,8 @@ for i = 1:nConfigs
     plot(pm10Mean(i), i, 'o', 'MarkerFaceColor',colors(i,:), 'MarkerEdgeColor','k');
 end
 set(gca,'YTick',1:nConfigs,'YTickLabel',labels);
-ylabel('Scenario');
-xlabel('PM10 Reduction (%)');
+ylabel('Scenario Identifier');
+xlabel('Particulate Matter 10 Reduction (Percent)');
 title('Coarse Particulate Matter Reduction Bounds');
 box on; grid on;
 
@@ -87,8 +87,8 @@ for i = 1:nConfigs
     end
 end
 set(gca,'YTick',1:nConfigs,'YTickLabel',labels);
-ylabel('Scenario');
-xlabel('AQI Hours Avoided');
+ylabel('Scenario Identifier');
+xlabel('Air Quality Index Hours Avoided');
 title('Air Quality Index Hours Avoided Bounds');
 box on; grid on;
 

--- a/plot_configuration_overlap.m
+++ b/plot_configuration_overlap.m
@@ -73,7 +73,7 @@ for i = 1:nConfigs
 end
 
 set(gca, 'YTick', y, 'YTickLabel', labels(sortIdx));
-xlabel('PM2.5 Reduction (%)');
+xlabel('Particulate Matter 2.5 Reduction (Percent)');
 title('Fine Particulate Matter Reduction with Envelope Bounds');
 grid on;
 
@@ -164,7 +164,7 @@ for i = 1:nConfigs
 end
 
 set(gca, 'YTick', y, 'YTickLabel', labels(sortIdx));
-xlabel('Annual Cost ($)');
+xlabel('Annual Cost (Dollars)');
 title('Operating Cost with Envelope Bounds');
 grid on;
 
@@ -224,8 +224,8 @@ for i = 1:nConfigs
     end
 end
 
-xlabel('PM2.5 Reduction (%)');
-ylabel('Annual Cost ($)');
+xlabel('Particulate Matter 2.5 Reduction (Percent)');
+ylabel('Annual Cost (Dollars)');
 title('Performance Overlap Across Configurations');
 grid on;
 

--- a/plot_correlation_analysis.m
+++ b/plot_correlation_analysis.m
@@ -45,8 +45,8 @@ for i = 1:nConfigs
         plot(data.lags(max_idx_pm25), max_corr_pm25, 'bo', 'MarkerSize', 8, 'LineWidth', 2);
         plot(data.lags(max_idx_pm10), max_corr_pm10, 'ro', 'MarkerSize', 8, 'LineWidth', 2);
 
-        xlabel('Lag (hours)');
-        ylabel('Cross-Correlation');
+        xlabel('Lag Time (Hours)');
+        ylabel('Cross Correlation');
         title(sprintf('%s\nOptimal Lag Fine Particulate Matter 2.5 Micrometers = %dh, Coarse Particulate Matter 10 Micrometers = %dh', ...
             strrep(config, '_', ' '), ...
             data.lags(max_idx_pm25), data.lags(max_idx_pm10)));

--- a/plot_cost_per_aqi_hour.m
+++ b/plot_cost_per_aqi_hour.m
@@ -107,7 +107,7 @@ end
 
 % Formatting
 set(gca, 'XTick', x, 'XTickLabel', modes);
-ylabel('Cost per AQI Hour Avoided ($)');
+ylabel('Cost per Air Quality Index Hour Avoided (Dollars)');
 title('Cost Effectiveness Comparison with Uncertainty Ranges');
 legend(barHandles, filters, 'Location', 'best');
 grid on;

--- a/plot_cost_vs_aqi_avoided.m
+++ b/plot_cost_vs_aqi_avoided.m
@@ -68,8 +68,8 @@ if sum(validIdx) >= 2
     plot(xFit, yFit, ':k', 'LineWidth', 1.5, 'DisplayName', 'Trend (means)');
 end
 
-xlabel('AQI Hours Avoided');
-ylabel('Total Operational Cost ($)');
+xlabel('Air Quality Index Hours Avoided');
+ylabel('Total Operational Cost (Dollars)');
 title('Cost Versus Air Quality Index Exposure Avoided with Scenario Bounds');
 grid on;
 legend('Location', 'eastoutside');

--- a/plot_cumulative_exposure.m
+++ b/plot_cumulative_exposure.m
@@ -17,6 +17,13 @@ elseif contains(lower(pmField), 'outdoor')
     envLabel = 'Outdoor';
 end
 
+readablePmLabel = expand_pm_label(pmLabel);
+if isempty(envLabel)
+    yLabelText = sprintf('Cumulative %s Exposure (Microgram Hours per Cubic Meter)', readablePmLabel);
+else
+    yLabelText = sprintf('Cumulative %s %s Exposure (Microgram Hours per Cubic Meter)', envLabel, readablePmLabel);
+end
+
 if isempty(summaryTable)
     warning('plot_cumulative_exposure: no data provided, skipping plot.');
     return;
@@ -67,17 +74,12 @@ for i = 1:height(uniqueConfigs)
     end
     title(sprintf('Cumulative Exposure for %s with %s Filter', ...
         strrep(loc, '_', ' '), strrep(filt, '_', ' ')));
-    xlabel('Hour of Year');
-    if isempty(envLabel)
-        ylabel(sprintf('Cumulative %s Exposure (µg/m³·h)', pmLabel));
-    else
-        ylabel(sprintf('Cumulative %s %s Exposure (µg/m³·h)', envLabel, pmLabel));
-    end
+    xlabel('Hour of the Year');
+    ylabel(yLabelText);
     legend(legendEntries, 'Location','eastoutside');
     grid on;
 end
 
-readablePmLabel = expand_pm_label(pmLabel);
 if isempty(envLabel)
     sgTxt = sprintf('Cumulative %s Exposure Over Time', readablePmLabel);
 else

--- a/plot_deterministic_bounds.m
+++ b/plot_deterministic_bounds.m
@@ -142,8 +142,8 @@ for i = 1:height(scenarios)
         'FontSize', 8, 'HorizontalAlignment', 'center');
 end
 
-xlabel('PM2.5 Reduction (%)');
-ylabel('Annual Operating Cost ($)');
+    xlabel('Particulate Matter 2.5 Reduction (Percent)');
+    ylabel('Annual Operating Cost (Dollars)');
 title('Feasible Operating Regions');
 legend({'Operating Range', 'Tight Envelope', 'Leaky Envelope'}, 'Location','eastoutside');
 grid on;
@@ -173,7 +173,7 @@ end
 bar(boundWidths);
 set(gca, 'XTick', 1:nScenarios, 'XTickLabel', scenarioLabels);
 xtickangle(45);
-ylabel('Absolute Bounds Width');
+ylabel('Absolute Bounds Width (Varies by Metric)');
 legend({'PM2.5 (µg/m³)', 'Cost ($)', 'Filter Hours'}, 'Location','northwestoutside');
 title('Physical Bounds Width by Scenario');
 grid on;
@@ -214,15 +214,15 @@ if ~isempty(exampleIdx)
         hold on;
         plot(hours, tightPM_subset, 'b-', 'LineWidth', 2);
         plot(hours, leakyPM_subset, 'b--', 'LineWidth', 2);
-        ylabel('Indoor PM2.5 (µg/m³)');
+        ylabel('Indoor Particulate Matter 2.5 Concentration (Micrograms per Cubic Meter)');
         ylim([0 max([tightPM_subset(:); leakyPM_subset(:)])*1.1]);
 
         yyaxis right
         boundWidth = abs(tightPM_subset - leakyPM_subset);
         plot(hours, boundWidth, 'r-', 'LineWidth', 1.5);
-        ylabel('Bounds Width (µg/m³)');
+        ylabel('Bounds Width (Micrograms per Cubic Meter)');
 
-        xlabel('Hour');
+        xlabel('Time in Hours');
         title(sprintf('Physical Bounds Evolution for %s %s %s During First Week', ...
             strrep(scenarios.location{exampleIdx}, '_', ' '), ...
             strrep(scenarios.filterType{exampleIdx}, '_', ' '), ...

--- a/plot_efficacy_scores.m
+++ b/plot_efficacy_scores.m
@@ -49,7 +49,7 @@ errorbar(1:nConfigs, efficacyScoreTable.mean_efficacy_score, ...
 % Formatting
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', scenarioLabels);
 xtickangle(45);
-ylabel('Composite Efficacy Score (0-100)');
+ylabel('Composite Efficacy Score (Zero to One Hundred)');
 title('Overall Intervention Efficacy Ranking');
 grid on;
 ylim([0 100]);
@@ -91,7 +91,7 @@ bar(1:nConfigs, efficacyScoreTable.leaky_efficacy_score, ...
 
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', scenarioLabels);
 xtickangle(45);
-ylabel('Efficacy Score');
+ylabel('Overall Efficacy Score');
 title('Building Envelope Performance Comparison');
 legend('Location', 'eastoutside');
 grid on;
@@ -101,7 +101,7 @@ nexttile;
 bar(efficacyScoreTable.score_range, 'FaceColor', cmap.gray, 'EdgeColor', 'k');
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', scenarioLabels);
 xtickangle(45);
-ylabel('Score Range (Tight - Leaky)');
+ylabel('Score Range from Tight to Leaky');
 title('Performance Uncertainty Range');
 grid on;
 
@@ -116,7 +116,7 @@ colormap(parula);
 cb = colorbar;
 ylabel(cb, 'Overall Efficacy Score');
 
-xlabel('PM2.5 Component Score');
+xlabel('Particulate Matter 2.5 Component Score');
 ylabel('Cost Effectiveness Component Score');
 title('Fine Particulate Matter Reduction Versus Cost Tradeoff');
 grid on;

--- a/plot_efficiency_cost_quadrant.m
+++ b/plot_efficiency_cost_quadrant.m
@@ -68,8 +68,8 @@ text(x_median*0.5, y_median*1.5, 'High Cost, Low Reduction', ...
 text(x_median*1.5, y_median*1.5, 'High Cost, High Reduction', ...
      'HorizontalAlignment', 'center', 'FontWeight', 'bold', 'Color', [0.5 0.5 0]);
 
-xlabel('% Indoor PM2.5 Reduction from Baseline');
-ylabel('Total Operational Cost ($)');
+xlabel('Indoor Particulate Matter 2.5 Reduction from Baseline (Percent)');
+ylabel('Total Operational Cost (Dollars)');
 title('Cost Versus Indoor Fine Particulate Matter Reduction with Uncertainty Regions');
 grid on;
 legend('Location', 'eastoutside');

--- a/plot_efficiency_cost_quadrant_pm10.m
+++ b/plot_efficiency_cost_quadrant_pm10.m
@@ -56,8 +56,8 @@ set(hX, 'DisplayName', 'Median Reduction');
 hY = yline(y_median, '--k', 'Median Cost', 'LineWidth', 1.5);
 set(hY, 'DisplayName', 'Median Cost');
 
-xlabel('% Indoor PM10 Reduction from Baseline');
-ylabel('Total Operational Cost ($)');
+xlabel('Indoor Particulate Matter 10 Reduction from Baseline (Percent)');
+ylabel('Total Operational Cost (Dollars)');
 title('Cost Versus Indoor Coarse Particulate Matter Under 10 Micrometers Reduction with Uncertainty Regions');
 grid on;
 legend('Location', 'eastoutside');

--- a/plot_envelope_sensitivity.m
+++ b/plot_envelope_sensitivity.m
@@ -200,7 +200,7 @@ end
 [sortedSens, sortIdx] = sort(meanSens, 'descend');
 barh(sortedSens);
 set(gca, 'YTick', 1:length(metrics), 'YTickLabel', metricLabels(sortIdx));
-xlabel('Mean Sensitivity (normalized)');
+xlabel('Mean Sensitivity (Normalized Units)');
 title('Parameter Sensitivity Ranking');
 grid on;
 
@@ -234,8 +234,8 @@ for i = 1:height(sensitivity)
     end
 end
 
-xlabel('Scenario');
-ylabel('Sensitivity (% change or absolute*)');
+xlabel('Scenario Identifier');
+ylabel('Sensitivity (Percent Change or Absolute Difference)');
 title('Envelope Sensitivity Across Scenarios');
 legend({'PM2.5','Cost','Filter Life'}, 'Location','eastoutside');
 set(gca, 'XTick', x, 'XTickLabel', scenarioLabels);
@@ -251,8 +251,8 @@ scatter(sensitivity.cost_sensitivity(validIdx), ...
     sensitivity.effectiveness_change(validIdx), ...
     100, 1:sum(validIdx), 'filled');
 
-xlabel('Cost Increase (%)');
-ylabel('Effectiveness Change (% points)');
+xlabel('Cost Increase (Percent)');
+ylabel('Effectiveness Change (Percentage Points)');
 title('Cost Impact Versus Effectiveness Change');
 colormap(lines(sum(validIdx)));
 

--- a/plot_event_metric_distributions.m
+++ b/plot_event_metric_distributions.m
@@ -20,8 +20,8 @@ if isempty(cleanTbl)
 end
 
 metrics = {'lag_peak','recovery_time','attenuation','auc_reduction'};
-labels = {'Lag to Indoor Peak (h)','Recovery Time (h)', ...
-          'Indoor/Outdoor Amplitude','AUC Reduction (frac)'};
+labels = {'Time to Indoor Peak (Hours)','Recovery Time (Hours)', ...
+          'Indoor to Outdoor Amplitude Ratio','Area Under Curve Reduction (Fraction)'};
 
 [G, groups] = findgroups(cleanTbl.config, cleanTbl.pollutant);
 grpLabels = strcat(strrep(groups(:,1),'_',' '), " (", groups(:,2), ")");
@@ -51,7 +51,7 @@ for m = 1:numel(metrics)
         plot(x,f,'DisplayName',grpLabels(g));
     end
     xlabel(labels{m});
-    ylabel('ECDF');
+    ylabel('Empirical Cumulative Distribution Function');
     title(sprintf('Empirical Cumulative Distribution of %s', strrep(metric,'_',' ')));
     legend('Location','best');
     grid on;

--- a/plot_event_response_analysis.m
+++ b/plot_event_response_analysis.m
@@ -55,7 +55,7 @@ b2 = bar(positions + offset, avg_durations, 0.4, 'FaceColor','flat');
 b2.CData = colors;
 hold on;
 errorbar(positions + offset, avg_durations, avg_durations - duration_bounds(:,1)', duration_bounds(:,2)' - avg_durations, 'k', 'LineStyle','none');
-ylabel('Avg Duration (hours)');
+ylabel('Average Duration (Hours)');
 
 text(0.02,0.98,'Error bars show tight/leaky bounds', 'Units','normalized', ...
     'VerticalAlignment','top','FontSize',8,'FontAngle','italic');
@@ -109,8 +109,8 @@ for i = 1:length(configs)
     end
 end
 
-xlabel('Peak Reduction (%)');
-ylabel('Integrated Reduction (%)');
+xlabel('Peak Concentration Reduction (Percent)');
+ylabel('Integrated Concentration Reduction (Percent)');
 title('Effectiveness of Event Responses');
 grid on;
 legend('Location','best');
@@ -143,7 +143,7 @@ end
 xlim([0 length(configs)+1]);
 set(gca, 'XTick', 1:length(configs), 'XTickLabel', labels);
 xtickangle(45);
-ylabel('Peak/Baseline Ratio');
+ylabel('Peak to Baseline Concentration Ratio');
 title('Distribution of Event Severity Levels');
 legend({'Tight','Leaky'}, 'Location', 'best');
 grid on;
@@ -212,8 +212,8 @@ for i = 1:nConfigs
     legendHandles(i) = scatter(NaN, NaN, 30, 'filled', 'MarkerFaceColor', colors(i,:), 'MarkerEdgeColor', 'k');
 end
 
-xlabel('Event Index');
-ylabel('Peak Reduction (%)');
+xlabel('Event Sequence Number');
+ylabel('Peak Concentration Reduction (Percent)');
 title('Event Response Metrics by Occurrence');
 % Filter out any invalid handles in case some configs lacked data
 valid = isgraphics(legendHandles);

--- a/plot_executive_summary.m
+++ b/plot_executive_summary.m
@@ -90,7 +90,7 @@ else
         end
     end
 
-    ylabel('Value');
+    ylabel('Metric Value (Varies by Category)');
     title('Active Intervention Results for Bakersfield');
     grid on;
 end
@@ -138,8 +138,8 @@ yMed = median(costTable.total_cost);
 xline(xMed, '--k', 'Median Reduction');
 yline(yMed, '--k', 'Median Cost');
 
-xlabel('PM2.5 Reduction (%)');
-ylabel('Annual Cost ($)');
+xlabel('Particulate Matter 2.5 Reduction (Percent)');
+ylabel('Annual Cost (Dollars)');
 title('Cost and Effectiveness Outcomes with Uncertainty Ranges');
 grid on;
 legend('Location', 'eastoutside');
@@ -176,7 +176,7 @@ for f = 1:length(filterTypes)
 end
 set(gca, 'XTick', positions, 'XTickLabel', filterTypes);
 xlabel('Filter Type');
-ylabel('PM2.5 Reduction (%)');
+ylabel('Particulate Matter 2.5 Reduction (Percent)');
 title('Performance Distribution Across Filter Types');
 grid on;
 legend(unique(get(gca,'Children')),'Location','bestoutside');
@@ -209,8 +209,8 @@ if length(performance) > 2
     yfit = polyval(p, xfit);
     hLine = plot(xfit, yfit, 'r--', 'LineWidth', 1.5, 'DisplayName', 'Trend Line');
 end
-xlabel('Mean PM2.5 Reduction (%)');
-ylabel('Uncertainty Range (% points)');
+xlabel('Mean Particulate Matter 2.5 Reduction (Percent)');
+ylabel('Uncertainty Range (Percentage Points)');
 title('Performance Versus Uncertainty Range');
 grid on;
 

--- a/plot_filter_life_envelope.m
+++ b/plot_filter_life_envelope.m
@@ -130,8 +130,8 @@ for i = 1:nConfigs
 
     % Formatting
     ylim([0 105]);
-    xlabel('Hour of Simulation');
-    ylabel('Filter Life (%)');
+    xlabel('Simulation Time (Hours)');
+    ylabel('Remaining Filter Life (Percent)');
     title(sprintf('Filter Life Envelope for %s %s %s', ...
         strrep(loc,'_',' '), strrep(filt,'_',' '), strrep(mode,'_',' ')), ...
         'Interpreter', 'none');

--- a/plot_filter_replacement.m
+++ b/plot_filter_replacement.m
@@ -125,7 +125,7 @@ end
 % Plot relative range
 bar(relativeRange', 'grouped');
 set(gca, 'XTick', 1:nFilters, 'XTickLabel', filters);
-ylabel('Relative Range (%)');
+ylabel('Relative Range (Percent)');
 title('Replacement Frequency Range by Filter Type');
 legend(modes, 'Location', 'best');
 grid on;

--- a/plot_intervention_efficacy_dashboard.m
+++ b/plot_intervention_efficacy_dashboard.m
@@ -146,7 +146,7 @@ function plotReductionEfficacy(costTable, pollutant)
     
     % Customize appearance
     set(gca, 'XTick', 1:length(labels), 'XTickLabel', labels);
-    ylabel(sprintf('%s Reduction (%%)', readablePollutant));
+    ylabel(sprintf('%s Concentration Reduction (Percent)', readablePollutant));
     title(sprintf('%s Reduction Efficacy', readablePollutant), 'FontWeight', 'bold');
     legend(modes, 'Location', 'best', 'Interpreter', 'none');
     grid on;
@@ -214,7 +214,7 @@ function plotScenarioBounds(costTable, summaryTable)
     end
     
     set(gca, 'YTick', y, 'YTickLabel', configLabels(sortIdx));
-    xlabel('PM2.5 Reduction (%)');
+    xlabel('Particulate Matter 2.5 Reduction (Percent)');
     title('Efficacy Bounds Across Tight and Leaky Homes', 'FontWeight', 'bold');
     grid on;
     xlim([0, max(boundsData(:,3)) * 1.1]);
@@ -269,8 +269,8 @@ function plotCostEffectivenessBubble(costTable)
          'HorizontalAlignment', 'left', 'VerticalAlignment', 'bottom', ...
          'FontWeight', 'bold', 'Color', [0.8 0 0]);
     
-    xlabel('PM2.5 Reduction (%)');
-    ylabel('Cost per μg/m³ Removed ($)');
+    xlabel('Particulate Matter 2.5 Reduction (Percent)');
+    ylabel('Cost per Microgram per Cubic Meter of Pollutant Removed (Dollars)');
     title('Cost Effectiveness Analysis Across Configurations', 'FontWeight', 'bold');
     
     % Add legend for bubble size
@@ -344,8 +344,8 @@ function plotCumulativeBenefit(summaryTable)
         end
     end
     
-    xlabel('Hours');
-    ylabel('Cumulative PM2.5 Reduction (μg/m³·h)');
+    xlabel('Time in Hours');
+    ylabel('Cumulative Particulate Matter 2.5 Reduction (Microgram Hours per Cubic Meter)');
     title('Cumulative Exposure Benefit During First Week', 'FontWeight', 'bold');
     legend('Location', 'best', 'Interpreter', 'none');
     grid on;
@@ -404,7 +404,7 @@ function plotBuildingEnvelopeSensitivity(costTable)
     barh(x, -normSens(sortIdx, 2), 'FaceColor', [0.9 0.3 0.3]);
     
     set(gca, 'YTick', x, 'YTickLabel', labels(sortIdx));
-    xlabel('Relative Sensitivity to Building Envelope (%)');
+    xlabel('Relative Sensitivity to the Building Envelope (Percent)');
     title('Building Envelope Impact on Performance Metrics', 'FontWeight', 'bold');
     
     % Add center line

--- a/plot_intervention_matrix.m
+++ b/plot_intervention_matrix.m
@@ -106,7 +106,7 @@ if ~isfinite(vmin) || ~isfinite(vmax) || vmin == vmax
 end
 caxis(ax1, [vmin vmax]);
 cb = colorbar(ax1);
-ylabel(cb, sprintf('%s Reduction (%%) Mean Value', readablePollutant));
+ylabel(cb, sprintf('Mean %s Concentration Reduction (Percent)', readablePollutant));
 
 % Set labels
 set(ax1, 'XTick', 1:nInt, 'XTickLabel', interventions);

--- a/plot_io_ratio_dynamics.m
+++ b/plot_io_ratio_dynamics.m
@@ -36,8 +36,8 @@ for i = 1:nConfigs
     yline(1, '--k', 'No Filtration');
     yline(data.stats.pm25_median, ':b', sprintf('Median: %.2f', data.stats.pm25_median));
     
-    xlabel('Hour');
-    ylabel('Indoor/Outdoor Ratio');
+    xlabel('Time Since Start (Hours)');
+    ylabel('Indoor to Outdoor Concentration Ratio');
     title(sprintf('Indoor to Outdoor Ratio Dynamics for %s with %s Filter', ...
         strrep(data.location, '_', ' '), strrep(data.filterType, '_', ' ')));
     legend({'PM2.5 Bounds', 'PM2.5 Mean', 'PM10 Bounds', 'PM10 Mean'}, 'Location', 'best');

--- a/plot_penetration_analysis.m
+++ b/plot_penetration_analysis.m
@@ -54,7 +54,7 @@ errorbar(x + width/2, pm10_factors, ...
     'k', 'LineStyle', 'none', 'HandleVisibility', 'off');
 
 set(gca, 'XTick', x, 'XTickLabel', labels);
-ylabel('Penetration Factor');
+ylabel('Particle Penetration Factor');
 legend([hPM25 hPM10], {'PM2.5', 'PM10'}, 'Location', 'best');
 title('Particle Penetration Factors by Configuration');
 grid on;
@@ -84,7 +84,7 @@ errorbar(x + width/2, pm10_removal, ...
     'k', 'LineStyle', 'none', 'HandleVisibility', 'off');
 
 set(gca, 'XTick', x, 'XTickLabel', labels);
-ylabel('Removal Efficiency (%)');
+ylabel('Removal Efficiency (Percent)');
 legend([hR25 hR10], {'PM2.5', 'PM10'}, 'Location', 'best');
 title('Particle Removal Efficiency by Configuration');
 grid on;
@@ -102,7 +102,7 @@ errorbar(x, size_ratio, ...
     'k', 'LineStyle', 'none', 'HandleVisibility', 'off');
 
 set(gca, 'XTick', x, 'XTickLabel', labels);
-ylabel('PM10/PM2.5 Penetration Ratio');
+ylabel('Particulate Matter 10 to Particulate Matter 2.5 Penetration Ratio');
 title('Size Dependent Penetration Ratio');
 yline(1, '--k', 'Equal Penetration');
 grid on;
@@ -133,8 +133,8 @@ if isfield(data, 'hourly_penetration_pm25')
     end
     plot(t, data.hourly_penetration_pm25(t), 'b-', 'LineWidth', 1.5);
     plot(t, data.hourly_penetration_pm10(t), 'r-', 'LineWidth', 1.5);
-    xlabel('Hour');
-    ylabel('Penetration Factor');
+    xlabel('Time in Hours');
+    ylabel('Particle Penetration Factor');
     title(sprintf('Penetration Temporal Variation for %s', strrep(config, '_', ' ')));
     legend({'PM2.5 Bounds', 'PM10 Bounds', 'PM2.5 Mean', 'PM10 Mean'}, 'Location', 'best');
     grid on;

--- a/plot_pm_envelope.m
+++ b/plot_pm_envelope.m
@@ -16,6 +16,11 @@ elseif contains(lower(pmField), 'outdoor')
 end
 
 readablePmLabel = expand_pm_label(pmLabel);
+if isempty(envLabel)
+    concentrationLabel = sprintf('%s Concentration (Micrograms per Cubic Meter)', readablePmLabel);
+else
+    concentrationLabel = sprintf('%s %s Concentration (Micrograms per Cubic Meter)', envLabel, readablePmLabel);
+end
 
 configs = unique(summaryTable(:, {'location','filterType'}));
 
@@ -115,12 +120,8 @@ for i = 1:height(configs)
         legendEntries{end+1} = sprintf('%s (mean)', modeName);
     end
 
-    xlabel('Hour of Year');
-    if isempty(envLabel)
-        ylabel(sprintf('%s Concentration (µg/m³)', pmLabel));
-    else
-        ylabel(sprintf('%s %s Concentration (µg/m³)', envLabel, pmLabel));
-    end
+    xlabel('Hour of the Year');
+    ylabel(concentrationLabel);
     title(sprintf('Hourly Concentration Bounds for %s with %s Filter', ...
         strrep(loc, '_', ' '), strrep(filt, '_', ' ')));
     legend(legendEntries, 'Location', 'best');
@@ -189,11 +190,7 @@ for i = 1:height(configs)
         end
     end
 
-    if isempty(envLabel)
-        xlabel(sprintf('%s Concentration (µg/m³)', pmLabel));
-    else
-        xlabel(sprintf('%s %s Concentration (µg/m³)', envLabel, pmLabel));
-    end
+    xlabel(concentrationLabel);
     ylabel('Probability');
     title('Distribution Across Building Envelopes');
     legend(modes, 'Location','eastoutside');
@@ -226,8 +223,8 @@ for i = 1:height(configs)
             'Color', colors(m,:), 'LineWidth', 1.5);
     end
 
-    xlabel('Hour of Year');
-    ylabel('Relative Bounds Width (%)');
+    xlabel('Hour of the Year');
+    ylabel('Relative Bounds Width (Percent)');
     title('Concentration Range Over Time');
     legend(modes, 'Location','eastoutside');
     grid on;

--- a/plot_scalar_ranges.m
+++ b/plot_scalar_ranges.m
@@ -58,9 +58,22 @@ hold on;
 values = rows.mean;
 lowerBounds = rows.lower_bound;
 upperBounds = rows.upper_bound;
-yLabelText = metricName;
-titleText = sprintf('Range for %s Across Tight and Leaky Envelopes', strrep(metricName, '_', ' '));
 noteText = '';
+
+switch lower(metricName)
+    case 'avg_indoor_pm25'
+        yLabelText = 'Average Indoor Particulate Matter 2.5 Concentration (Micrograms per Cubic Meter)';
+        titleText = 'Range of Average Indoor Particulate Matter 2.5 Concentration Across Tight and Leaky Envelopes';
+    case 'avg_indoor_pm10'
+        yLabelText = 'Average Indoor Particulate Matter 10 Concentration (Micrograms per Cubic Meter)';
+        titleText = 'Range of Average Indoor Particulate Matter 10 Concentration Across Tight and Leaky Envelopes';
+    case 'total_cost'
+        yLabelText = 'Total Operational Cost (Dollars)';
+        titleText = 'Total Operational Cost Range Across Tight and Leaky Envelopes';
+    otherwise
+        yLabelText = strrep(metricName, '_', ' ');
+        titleText = sprintf('Range for %s Across Tight and Leaky Envelopes', strrep(metricName, '_', ' '));
+end
 
 if strcmp(metricName, 'filter_replaced')
     hoursPerYear = 8760; % Consistent assumption used throughout reports

--- a/plot_statistical_summary.m
+++ b/plot_statistical_summary.m
@@ -95,8 +95,8 @@ avgRange = mean(summaryStats(:,1:4), 2, 'omitnan');
 avgPerformance = 100 - summaryStats(:,5); % Convert to reduction
 
 scatter(avgRange, avgPerformance, 100, 1:nConfigs, 'filled');
-xlabel('Average Range (%)');
-ylabel('PM2.5 Reduction Performance');
+xlabel('Average Range (Percent)');
+ylabel('Particulate Matter 2.5 Reduction Performance');
 title('Performance Versus Range Tradeoff');
 colormap(lines(nConfigs));
 grid on;
@@ -113,7 +113,7 @@ validIdx = sortIdx(sortedCost > 0);
 if ~isempty(validIdx)
     barh(1:length(validIdx), sortedCost(sortedCost > 0));
     set(gca, 'YTick', 1:length(validIdx), 'YTickLabel', configLabels(validIdx));
-    xlabel('Cost Range (%)');
+    xlabel('Cost Range (Percent)');
     title('Cost Variability Ranking');
     grid on;
 end
@@ -126,7 +126,7 @@ heatmapData = summaryStats(:,1:4)';
 imagesc(heatmapData);
 colormap(flipud(hot));
 cb = colorbar;
-ylabel(cb, 'Range (%)');
+ylabel(cb, 'Range (Percent)');
 
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', configLabels);
 set(gca, 'YTick', 1:4, 'YTickLabel', metricLabels);

--- a/plot_temporal_patterns.m
+++ b/plot_temporal_patterns.m
@@ -36,8 +36,8 @@ for i = 1:length(configs)
     end
 end
 
-xlabel('Hour of Day');
-ylabel('Average I/O Ratio');
+xlabel('Hour of the Day');
+ylabel('Average Indoor to Outdoor Ratio');
 title('Diurnal Variation in Filtration Performance');
 if ~isempty(diurnalHandles)
     legend(diurnalHandles, diurnalLabels, 'Location', 'best');
@@ -80,7 +80,7 @@ if any(~isnan(stab_lower))
         stability_scores - stab_lower, stab_upper - stability_scores, 'k.', 'LineStyle','none');
 end
 set(gca, 'XTick', 1:length(labels), 'XTickLabel', labels);
-ylabel('Stability Score');
+ylabel('Filtration Stability Score');
 title('Filtration Performance Stability Over Time');
 grid on;
 
@@ -112,8 +112,8 @@ for i = 1:length(configs)
     end
 end
 
-xlabel('Day');
-ylabel('Daily Average I/O Ratio');
+xlabel('Day of Observation');
+ylabel('Daily Average Indoor to Outdoor Ratio');
 title('Filtration Performance Trend Over Time');
 if ~isempty(lineHandles)
     legend(lineHandles, legendLabels, 'Location', 'best');

--- a/plot_trigger_response_analysis.m
+++ b/plot_trigger_response_analysis.m
@@ -44,8 +44,8 @@ if ~isempty(lag_times)
     for i = 1:length(labels)
         text(lag_times(i)+0.1, peak_reductions(i), labels{i}, 'FontSize', 8);
     end
-    xlabel('Average Lag Time (hours)');
-    ylabel('Average Peak Reduction (%)');
+    xlabel('Average Lag Time (Hours)');
+    ylabel('Average Peak Concentration Reduction (Percent)');
     title('Trigger Response Performance Summary');
     grid on;
 end
@@ -75,7 +75,7 @@ for i = 1:nConfigs
 end
 
 set(gca, 'XTick', 1:nConfigs, 'XTickLabel', labels);
-ylabel('Response Time (hours)');
+ylabel('Response Time (Hours)');
 title('Average System Response Time by Configuration');
 xtickangle(45);
 grid on;
@@ -105,7 +105,7 @@ hActive = bar(x - width/2, active_ratios, width, 'FaceColor', [0.2 0.6 0.2]);
 hold on;
 hInactive = bar(x + width/2, inactive_ratios, width, 'FaceColor', [0.8 0.2 0.2]);
 set(gca, 'XTick', x, 'XTickLabel', labels);
-ylabel('I/O Ratio');
+ylabel('Indoor to Outdoor Ratio');
 legend([hActive hInactive], {'Active', 'Inactive'}, 'Location', 'best');
 title('Active and Inactive Performance Comparison');
 xtickangle(45);
@@ -196,7 +196,7 @@ errorbar(x + width/2, pm10_factors, ...
     'k', 'LineStyle', 'none');
 
 set(gca, 'XTick', x, 'XTickLabel', labels);
-ylabel('Penetration Factor');
+ylabel('Particle Penetration Factor');
 legend({'PM2.5', 'PM10'}, 'Location', 'best');
 title('Particle Penetration Factors by Configuration');
 grid on;
@@ -224,7 +224,7 @@ errorbar(x + width/2, pm10_removal, ...
     'k', 'LineStyle', 'none', 'HandleVisibility', 'off');
 
 set(gca, 'XTick', x, 'XTickLabel', labels);
-ylabel('Removal Efficiency (%)');
+ylabel('Removal Efficiency (Percent)');
 legend({'PM2.5', 'PM10'}, 'Location', 'best');
 title('Particle Removal Efficiency by Configuration');
 grid on;
@@ -242,7 +242,7 @@ errorbar(x, size_ratio, ...
     'k', 'LineStyle', 'none', 'HandleVisibility', 'off');
 
 set(gca, 'XTick', x, 'XTickLabel', labels);
-ylabel('PM10/PM2.5 Penetration Ratio');
+ylabel('Particulate Matter 10 to Particulate Matter 2.5 Penetration Ratio');
 title('Size Dependent Penetration Ratio');
 yline(1, '--k', 'Equal Penetration');
 grid on;
@@ -257,8 +257,8 @@ if isfield(data, 'hourly_penetration_pm25')
     plot(t, data.hourly_penetration_pm25(t), 'b-', 'LineWidth', 1.5);
     hold on;
     plot(t, data.hourly_penetration_pm10(t), 'r-', 'LineWidth', 1.5);
-    xlabel('Hour');
-    ylabel('Penetration Factor');
+    xlabel('Time in Hours');
+    ylabel('Particle Penetration Factor');
     title(sprintf('Penetration Temporal Variation for %s', strrep(config, '_', ' ')));
     legend({'PM2.5', 'PM10'}, 'Location', 'best');
     grid on;
@@ -318,7 +318,7 @@ b2 = bar(positions + offset, avg_durations, 0.4, 'FaceColor','flat');
 b2.CData = colors;
 hold on;
 errorbar(positions + offset, avg_durations, avg_durations - duration_bounds(:,1)', duration_bounds(:,2)' - avg_durations, 'k', 'LineStyle','none');
-ylabel('Avg Duration (hours)');
+ylabel('Average Duration (Hours)');
 
 text(0.02,0.98,'Error bars show tight/leaky bounds', 'Units','normalized', ...
     'VerticalAlignment','top','FontSize',8,'FontAngle','italic');
@@ -346,8 +346,8 @@ for i = 1:length(configs)
 end
 
 scatter(peak_reductions, integrated_reductions, 100, 1:length(configs), 'filled');
-xlabel('Peak Reduction (%)');
-ylabel('Integrated Reduction (%)');
+xlabel('Peak Concentration Reduction (Percent)');
+ylabel('Integrated Concentration Reduction (Percent)');
 title('Effectiveness of Event Responses');
 colormap(lines(length(configs)));
 grid on;
@@ -380,7 +380,7 @@ end
 xlim([0 length(configs)+1]);
 set(gca, 'XTick', 1:length(configs), 'XTickLabel', labels);
 xtickangle(45);
-ylabel('Peak/Baseline Ratio');
+ylabel('Peak to Baseline Ratio');
 title('Distribution of Event Severity Levels');
 legend({'Tight','Leaky'}, 'Location', 'best');
 grid on;
@@ -416,8 +416,8 @@ for i = 1:length(configs)
     end
 end
 
-xlabel('Hour of Day');
-ylabel('Average I/O Ratio');
+xlabel('Hour of the Day');
+ylabel('Average Indoor to Outdoor Ratio');
 title('Diurnal Variation in Filtration Performance');
 legend(strrep(configs, '_', ' '), 'Location', 'best');
 grid on;
@@ -442,7 +442,7 @@ end
 
 bar(stability_scores, 'FaceColor', [0.4 0.6 0.8]);
 set(gca, 'XTick', 1:length(labels), 'XTickLabel', labels);
-ylabel('Stability Score');
+ylabel('Filtration Stability Score');
 title('Filtration Performance Stability Over Time');
 grid on;
 
@@ -460,8 +460,8 @@ for i = 1:length(configs)
     end
 end
 
-xlabel('Day');
-ylabel('Daily Average I/O Ratio');
+xlabel('Day of Observation');
+ylabel('Daily Average Indoor to Outdoor Ratio');
 title('Filtration Performance Trend Over Time');
 legend(strrep(configs, '_', ' '), 'Location', 'best');
 grid on;
@@ -501,8 +501,8 @@ for i = 1:nConfigs
         plot(data.lags(max_idx_pm25), max_corr_pm25, 'bo', 'MarkerSize', 8, 'LineWidth', 2);
         plot(data.lags(max_idx_pm10), max_corr_pm10, 'ro', 'MarkerSize', 8, 'LineWidth', 2);
         
-        xlabel('Lag (hours)');
-        ylabel('Cross-Correlation');
+        xlabel('Lag Time (Hours)');
+        ylabel('Cross Correlation');
         title(sprintf('%s\nOptimal Lag Fine Particulate Matter 2.5 Micrometers = %dh, Coarse Particulate Matter 10 Micrometers = %dh', ...
             strrep(config, '_', ' '), ...
             data.lags(max_idx_pm25), data.lags(max_idx_pm10)));
@@ -606,7 +606,7 @@ bar(x + width/2, pm10_ranges, width, 'FaceColor', [0.8 0.3 0.3]);
 
 set(gca, 'XTick', x, 'XTickLabel', labels);
 xtickangle(45);
-ylabel('Uncertainty Range (%)');
+ylabel('Uncertainty Range (Percent)');
 legend({'PM2.5', 'PM10'}, 'Location', 'best');
 title('Building Envelope Uncertainty Range by Configuration');
 grid on;
@@ -626,8 +626,8 @@ if isfield(data, 'hourly_ci_pm25')
     hold on;
     plot(t, data.hourly_mean_pm25(t), 'b-', 'LineWidth', 2);
     
-    xlabel('Hour');
-    ylabel('Indoor PM2.5 (μg/m³)');
+    xlabel('Time in Hours');
+    ylabel('Indoor Particulate Matter 2.5 Concentration (Micrograms per Cubic Meter)');
     title(sprintf('Confidence Intervals for %s', strrep(config, '_', ' ')));
     legend({'Envelope Bounds', 'Mean'}, 'Location', 'best');
     grid on;
@@ -651,7 +651,7 @@ if ~isempty(contribution_data)
     bar(contribution_data', 'stacked');
     set(gca, 'XTick', 1:length(configs), 'XTickLabel', labels);
     xtickangle(45);
-    ylabel('Contribution to Total Uncertainty (%)');
+    ylabel('Contribution to Total Uncertainty (Percent)');
     legend(contribution_labels, 'Location', 'best');
     title('Uncertainty Source Contribution Analysis');
     grid on;
@@ -734,7 +734,7 @@ for i = 1:n
 end
 
     xlabel('Hours Relative to Outdoor Peak');
-    ylabel('Event Number');
+    ylabel('Event Count');
     yticks(1:n);
     ylim([0 n+1]);
     title(sprintf('Event Timeline for %s', strrep(configName,'_',' ')));
@@ -792,8 +792,8 @@ for i = 1:nConfigs
     legendHandles(i) = scatter(NaN, NaN, 30, 'filled', 'MarkerFaceColor', colors(i,:), 'MarkerEdgeColor', 'k');
 end
 
-xlabel('Event Index');
-ylabel('Peak Reduction (%)');
+xlabel('Event Sequence Number');
+ylabel('Peak Concentration Reduction (Percent)');
 title('Event Response Metrics by Occurrence');
 % Filter out invalid handles before creating the legend
 valid = isgraphics(legendHandles);
@@ -878,7 +878,7 @@ labels = {'Building Envelope','Outdoor Variability','System Response','Measureme
 
 barh(sortedVals,'FaceColor',[0.4 0.6 0.8]);
 set(gca,'YTick',1:numel(order),'YTickLabel',labels(order));
-xlabel('Contribution (%)');
+xlabel('Contribution (Percent)');
 title('Uncertainty Contribution Sensitivity Analysis');
 grid on;
 end

--- a/plot_uncertainty_analysis.m
+++ b/plot_uncertainty_analysis.m
@@ -35,7 +35,7 @@ h10 = bar(x + width/2, pm10_ranges, width, 'FaceColor', [0.8 0.3 0.3]);
 
 set(gca, 'XTick', x, 'XTickLabel', labels);
 xtickangle(45);
-ylabel('Scenario Range (%)');
+ylabel('Scenario Range (Percent)');
 legend([h25 h10], {'PM2.5', 'PM10'}, 'Location', 'best');
 title('Building Envelope Scenario Bounds Comparison');
 grid on;
@@ -55,9 +55,8 @@ if isfield(data, 'hourly_ci_pm25')
     hold on;
     plot(t, data.hourly_mean_pm25(t), 'b-', 'LineWidth', 2);
 
-    xlabel('Hour');
-    % Use TeX interpreter for micro symbol and superscript
-    ylabel('Indoor PM2.5 (\mu g/m^3)', 'Interpreter', 'tex');
+    xlabel('Time in Hours');
+    ylabel('Indoor Particulate Matter 2.5 Concentration (Micrograms per Cubic Meter)');
     title(sprintf('Confidence Intervals for %s', strrep(config, '_', ' ')));
     legend({'Envelope Bounds', 'Mean'}, 'Location', 'best');
     grid on;
@@ -92,7 +91,7 @@ if ~isempty(contribution_data)
 
     set(gca, 'XTick', 1:length(configs), 'XTickLabel', labels);
     xtickangle(45);
-    ylabel('Contribution to Total Range (%)');
+    ylabel('Contribution to Total Range (Percent)');
     legend(contribution_labels, 'Location', 'best');
     title('Scenario Bounds Source Contribution Analysis');
     grid on;
@@ -133,7 +132,7 @@ labels = {'Building Envelope','Outdoor Variability','System Response','Measureme
 barh(sortedVals, 'FaceColor', [0.4 0.6 0.8]);
 set(gca,'YTick',1:numel(order),'YTickLabel',labels(order));
 set(gca,'YDir','reverse');
-xlabel('Contribution (%)');
+xlabel('Contribution (Percent)');
 title('Uncertainty Contribution Sensitivity Analysis');
 grid on;
 end


### PR DESCRIPTION
## Summary
- rewrite axis labels across the plotting utilities in plain English without abbreviations
- harmonize particulate matter terminology and units so each chart clearly states the measured quantity
- ensure time- and event-based analyses describe axes with complete phrases for better readability

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c9de8e59b08327b3c7b05ea91c8e81