### PR TITLE
Fix complex warning in airflow penalty plot

### DIFF
--- a/plot_airflow_penalty.m
+++ b/plot_airflow_penalty.m
@@ -137,6 +137,8 @@ end
 % Ensure real values before plotting
 locationMeans  = real(locationMeans);
 locationRanges = real(locationRanges);
+locationLower  = real(locationLower);
+locationUpper  = real(locationUpper);
 
 b = bar(locationMeans, 'grouped');
 for i = 1:length(b)


### PR DESCRIPTION
## Summary
- coerce location-specific airflow penalty bounds to real values before plotting
- prevents complex-valued inputs from reaching the grouped error bars

## Testing
- not run (MATLAB environment not available)


------
https://chatgpt.com/codex/tasks/task_e_68c9efb19000832785775783bc7e1463