### PR TITLE
Ensure figure captions reserve space below plots

### DIFF
--- a/add_figure_caption.m
+++ b/add_figure_caption.m
@@ -4,7 +4,8 @@ function add_figure_caption(fig, captionText)
 %   ADD_FIGURE_CAPTION(FIG, CAPTIONTEXT) adds CAPTIONTEXT as centered text
 %   across the bottom of the figure window. Existing captions created by
 %   this helper are removed so the caption can be updated when figures are
-%   regenerated.
+%   regenerated. Space is reserved beneath the plots so the caption never
+%   overlaps axes labels.
 
 if nargin < 1 || isempty(fig)
     fig = gcf;
@@ -21,17 +22,177 @@ end
 if isstring(captionText)
     captionText = join(captionText, newline);
 end
+captionText = char(captionText);
 
-annotation(fig, 'textbox', [0.05 0.005 0.9 0.11], ...
-    'String', char(captionText), ...
+fontSize = 10;
+topPadding = 40;      % pixels between caption and the closest axes
+bottomPadding = 16;   % pixels beneath the caption text block
+
+% Switch to pixel units so geometry math is consistent across platforms
+originalFigUnits = fig.Units;
+cleanup = onCleanup(@() set(fig, 'Units', originalFigUnits));
+fig.Units = 'pixels';
+
+textHeight = measure_caption_height(fig, captionText, fontSize);
+requiredMargin = textHeight + topPadding + bottomPadding;
+
+[marginPixels, figHeight] = ensure_caption_margin(fig, requiredMargin);
+
+annotationBottom = bottomPadding / figHeight;
+annotationTop = (marginPixels - topPadding) / figHeight;
+annotationHeight = max(annotationTop - annotationBottom, textHeight / figHeight);
+if ~isfinite(annotationHeight) || annotationHeight <= 0
+    annotationBottom = 0;
+    annotationHeight = max(marginPixels / figHeight, 0.05);
+end
+
+annotation(fig, 'textbox', [0.05 annotationBottom 0.9 annotationHeight], ...
+    'String', captionText, ...
     'Tag', 'autoFigureCaption', ...
     'Interpreter', 'none', ...
+    'Units', 'normalized', ...
     'HorizontalAlignment', 'center', ...
     'VerticalAlignment', 'top', ...
-    'FontSize', 10, ...
+    'FontSize', fontSize, ...
     'EdgeColor', 'none', ...
     'BackgroundColor', 'white', ...
-    'Margin', 2, ...
+    'Margin', 6, ...
     'FitBoxToText', 'off', ...
     'LineStyle', 'none');
+end
+
+function textHeight = measure_caption_height(fig, captionText, fontSize)
+%MEASURE_CAPTION_HEIGHT Determine the rendered height of the caption text.
+temp = annotation(fig, 'textbox', [0 0 1 1], ...
+    'String', captionText, ...
+    'Interpreter', 'none', ...
+    'Units', 'pixels', ...
+    'Visible', 'off', ...
+    'FitBoxToText', 'on', ...
+    'HorizontalAlignment', 'center', ...
+    'VerticalAlignment', 'top', ...
+    'FontSize', fontSize, ...
+    'Margin', 6, ...
+    'LineStyle', 'none');
+extent = temp.Extent;
+textHeight = extent(4);
+delete(temp);
+end
+
+function [marginPixels, figHeight] = ensure_caption_margin(fig, requiredMargin)
+%ENSURE_CAPTION_MARGIN Expand the figure and shift plots to create space.
+storedMargin = getappdata(fig, 'CaptionMarginPixels');
+positionables = gather_positionable_objects(fig);
+minBottom = compute_min_bottom(positionables);
+
+if isempty(storedMargin)
+    currentMargin = minBottom;
+else
+    currentMargin = max(storedMargin, minBottom);
+end
+
+newMargin = max(currentMargin, requiredMargin);
+additionalMargin = newMargin - currentMargin;
+
+if additionalMargin > 0
+    figPos = fig.Position;
+    newBottom = max(figPos(2) - additionalMargin, 0);
+    fig.Position = [figPos(1), newBottom, figPos(3), figPos(4) + additionalMargin];
+    shift_positionables(positionables, additionalMargin);
+end
+
+setappdata(fig, 'CaptionMarginPixels', newMargin);
+figHeight = fig.Position(4);
+marginPixels = newMargin;
+end
+
+function handles = gather_positionable_objects(fig)
+%GATHER_POSITIONABLE_OBJECTS Identify objects that should move with margins.
+allObjects = findall(fig);
+mask = false(size(allObjects));
+
+for idx = 1:numel(allObjects)
+    obj = allObjects(idx);
+    if obj == fig
+        continue;
+    end
+    if isprop(obj, 'Position') && isprop(obj, 'Units')
+        if isprop(obj, 'Tag') && strcmp(obj.Tag, 'autoFigureCaption')
+            continue;
+        end
+        mask(idx) = true;
+    end
+end
+
+handles = allObjects(mask);
+end
+
+function minBottom = compute_min_bottom(objects)
+%COMPUTE_MIN_BOTTOM Find the closest object to the bottom of the figure.
+if isempty(objects)
+    minBottom = 0;
+    return;
+end
+
+bottoms = inf(numel(objects), 1);
+for idx = 1:numel(objects)
+    obj = objects(idx);
+    try
+        originalUnits = obj.Units;
+    catch
+        originalUnits = 'pixels';
+    end
+    try
+        obj.Units = 'pixels';
+        pos = obj.Position;
+        if numel(pos) >= 2
+            bottoms(idx) = pos(2);
+        end
+    catch
+        % Ignore objects that do not expose position in pixels
+    end
+    try
+        obj.Units = originalUnits;
+    catch
+        % Some objects do not permit unit assignment; ignore gracefully.
+    end
+end
+
+finiteBottoms = bottoms(isfinite(bottoms));
+if isempty(finiteBottoms)
+    minBottom = 0;
+else
+    minBottom = min(finiteBottoms);
+end
+end
+
+function shift_positionables(objects, delta)
+%SHIFT_POSITIONABLES Move all position-aware objects upward by DELTA pixels.
+if delta <= 0 || isempty(objects)
+    return;
+end
+
+for idx = 1:numel(objects)
+    obj = objects(idx);
+    try
+        originalUnits = obj.Units;
+    catch
+        originalUnits = 'pixels';
+    end
+    try
+        obj.Units = 'pixels';
+        pos = obj.Position;
+        if numel(pos) >= 2
+            pos(2) = pos(2) + delta;
+            obj.Position = pos;
+        end
+    catch
+        % Leave objects we cannot move alone.
+    end
+    try
+        obj.Units = originalUnits;
+    catch
+        % Ignore failures when restoring units.
+    end
+end
 end


### PR DESCRIPTION
## Summary
- dynamically measure caption height and allocate dedicated bottom margin for figure descriptions
- expand the figure window when needed and shift plots upward so axis labels stay visible
- render the caption within the reserved margin using consistent formatting

## Testing
- not run (MATLAB environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9f4520a248327870f5c0c50f632c5