### PR TITLE
Fix caption height measurement without Extent property

### DIFF
--- a/add_figure_caption.m
+++ b/add_figure_caption.m
@@ -74,8 +74,13 @@ temp = annotation(fig, 'textbox', [0 0 1 1], ...
     'FontSize', fontSize, ...
     'Margin', 6, ...
     'LineStyle', 'none');
-extent = temp.Extent;
-textHeight = extent(4);
+drawnow limitrate nocallbacks;
+pos = temp.Position;
+if numel(pos) >= 4
+    textHeight = pos(4);
+else
+    textHeight = 0;
+end
 delete(temp);
 end
 


### PR DESCRIPTION
## Summary
- compute caption text height using the annotation position instead of the unavailable `Extent` property
- trigger a render pass before measuring and keep a fallback when the position data is missing

## Testing
- not run (MATLAB executable not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68c9f7ad7158832788c33382d9756f78