### PR TITLE
Inline MATLAB path setup

### DIFF
--- a/generate_all_plots.m
+++ b/generate_all_plots.m
@@ -1,4 +1,6 @@
 function generate_all_plots(summaryTable, rangeTable, filterComparisonTable, healthExposureTable, avoidedExposureTable, costTable, tradeoffTable, figuresDir)
+[thisDir, ~, ~] = fileparts(mfilename('fullpath'));
+addpath(thisDir);
 if ~exist(figuresDir, 'dir')
     mkdir(figuresDir);
 end

--- a/main.m
+++ b/main.m
@@ -3,6 +3,10 @@
 
 close all; clear all; clc;
 
+% Ensure helper functions are accessible when the script is run from elsewhere
+[thisDir, ~, ~] = fileparts(mfilename('fullpath'));
+addpath(thisDir);
+
 %%  1. Setup (unchanged from original)
 disp("Starting enhanced air quality simulation pipeline...");
 


### PR DESCRIPTION
## Summary
- inline a minimal addpath call in `main.m` so helper scripts resolve when run from other directories
- apply the same localized path setup within `generate_all_plots` for standalone execution
- drop the previously added `initialize_project_paths.m` helper to keep the change surgical

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ca1bc342ac8327a2e4f62f336561bf